### PR TITLE
Fix REQUIRE_INTERNET: don't block the menu when offline

### DIFF
--- a/new_master.py
+++ b/new_master.py
@@ -412,6 +412,14 @@ def backup_data():
 
 
 def main():
+    # If REQUIRE_INTERNET is enabled, refuse to start the quiz while offline.
+    # This only blocks the question-asking (credit-earning) flow -- the menu,
+    # redeem, practice and stats screens all remain usable offline.
+    if get_config().get("REQUIRE_INTERNET", False) and not has_internet():
+        print(Fore.RED + "İnternet bağlantısı yok. Soru sorma özelliği devre dışı (REQUIRE_INTERNET etkin)." + Style.RESET_ALL)
+        lg("REQUIRE_INTERNET is enabled but no internet connection was detected. Aborting quiz start.")
+        input("\nAna menüye dönmek için Enter'a basın...")
+        return
     user = load_data(get_current_user())
     if get_config()["Credit_Reset_Weekly"]:
         if check_weekly_reset(user):
@@ -445,13 +453,6 @@ def starter(get_ready:bool=False):
     config = get_config()  # Ensure config is loaded and repaired if needed
     SOURCE = config.get("Source_Language", "Türkçe")
     TARGET = config.get("Target_Language", "İngilizce")
-
-    # If REQUIRE_INTERNET is enabled, refuse to start the quiz while offline.
-    if config.get("REQUIRE_INTERNET", False) and not has_internet():
-        print(Fore.RED + "İnternet bağlantısı yok. Sorular başlatılamıyor (REQUIRE_INTERNET etkin)." + Style.RESET_ALL)
-        lg("REQUIRE_INTERNET is enabled but no internet connection was detected. Aborting quiz start.")
-        sys.exit(0)
-
     cls()
     if not get_ready:
         main()


### PR DESCRIPTION
## Summary

Fixes the offline behavior of the `REQUIRE_INTERNET` config so that only the quiz (credit-earning question flow) is disabled when the machine is offline — not the whole app.

In v2.1.5 the connectivity guard lived in `starter()`, which runs at boot via `starter(get_ready=True)` in `coalide.py` **before** the menu opens. With `REQUIRE_INTERNET` on, an offline machine would `sys.exit(0)` during startup and never reach the menu, making redeem/practice/stats unreachable too.

## Changes

- Move the offline guard out of `starter()` and into `main()` (the quiz entry point), so the menu, redeem, practice, and stats screens all stay usable offline.
- Return to the menu gracefully (print a message + wait for Enter) instead of `sys.exit()`.
- `REQUIRE_INTERNET` config key remains, defaulting to `True`.
- Connectivity is checked via `has_internet()`, a quick TCP socket to Google's public DNS (`8.8.8.8:53`).

## Behavior

- Offline + `REQUIRE_INTERNET=true`: menu and all non-quiz screens open normally; launching the quiz shows a message and returns to the menu.
- Online, or `REQUIRE_INTERNET=false`: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACRb8h6pv7sCL3Bs5Chfhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACRb8h6pv7sCL3Bs5Chfhy)_