### PR TITLE
Add parental server: stats dashboard, API, Telegram report, web admin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -48,6 +48,7 @@ def pack_data(target_dir=".", output_dir="packaged_data"):
 RELEASE_CLEAN_PATTERNS = [
     ".git",
     ".env",
+    "serverside",       # parent-side stats API + web dashboard (never ships)
     "env",
     "venv",
     ".venv",
@@ -59,6 +60,7 @@ RELEASE_CLEAN_PATTERNS = [
     "words.json",
     "*_data.json",      # per-user balance/credits files
     "current_user.json",
+    ".config_sync.json",  # local record of the last synced config/words revision
     "version.json",
     "config.json",      # regenerated with defaults on first run
     "sent_tg_messages.json",

--- a/config_sync.py
+++ b/config_sync.py
@@ -1,0 +1,172 @@
+"""
+Coalide — config & words sync (client side).
+
+The parental stats server (see serverside/) runs on a DIFFERENT device, so it
+cannot touch this machine's files directly. This module keeps them in sync over
+HTTP: when the menu opens it pushes the current config.json / words.json and a
+hash of ADMIN_PASSWORD to the server, then pulls back anything the parent has
+changed through the web admin and applies it locally.
+
+Mirrors stats_reporter.py's rules:
+  - Runs on a daemon thread; never blocks the menu.
+  - Silent on failure (offline, no server, placeholder URL -> nothing happens).
+  - Opt-in: does nothing until STATS_SERVER_URL points at a real server.
+
+Revision tracking: the server hands out an integer `rev` for config and words
+that increases every time the parent edits them. We remember the last rev we
+applied in .config_sync.json and only re-write local files when the server has
+something newer — so a parent edit lands on the next menu open, and nothing is
+overwritten needlessly.
+"""
+
+import hashlib
+import json
+import os
+import threading
+from datetime import datetime
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = os.path.join(BASE_DIR, "config.json")
+WORDS_FILE = os.path.join(BASE_DIR, "words.json")
+PROGRESS_FILE = os.path.join(BASE_DIR, "progress.json")
+ENV_FILE = os.path.join(BASE_DIR, ".env")
+SYNC_STATE_FILE = os.path.join(BASE_DIR, ".config_sync.json")
+
+_PLACEHOLDER_MARKERS = ("IP-TO-YOUR", "YOUR-PARENT-SERVER", "example.com")
+_REQUEST_TIMEOUT = 5
+
+
+def _load_json(path, fallback):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return fallback
+
+
+def _save_json(path, data):
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=4)
+    os.replace(tmp, path)
+
+
+def _admin_hash() -> str | None:
+    """SHA-256 hex of ADMIN_PASSWORD (env first, then .env). None if unset."""
+    pw = os.environ.get("ADMIN_PASSWORD")
+    if not pw:
+        try:
+            with open(ENV_FILE, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("ADMIN_PASSWORD=") and "=" in line:
+                        pw = line.split("=", 1)[1].strip().strip('"').strip("'")
+                        break
+        except OSError:
+            pass
+    if not pw:
+        return None
+    return hashlib.sha256(pw.encode("utf-8")).hexdigest()
+
+
+def _sync_state() -> dict:
+    st = _load_json(SYNC_STATE_FILE, {})
+    return st if isinstance(st, dict) else {}
+
+
+def _reconcile_progress(words: list) -> None:
+    """Drop progress entries for words the parent removed, so progress.json
+    doesn't accumulate orphans after a server-side word deletion."""
+    prog = _load_json(PROGRESS_FILE, None)
+    if not isinstance(prog, dict):
+        return
+    targets = {w.get("target") for w in words if isinstance(w, dict)}
+    pruned = {k: v for k, v in prog.items() if k in targets}
+    if len(pruned) != len(prog):
+        _save_json(PROGRESS_FILE, pruned)
+
+
+def _push():
+    try:
+        from utils import get_config, lg
+    except Exception:
+        return
+    try:
+        cfg = get_config()
+        if not cfg.get("CONFIG_SYNC_ENABLED", True):
+            return
+        url = str(cfg.get("STATS_SERVER_URL", "")).strip()
+        if not url or any(m in url for m in _PLACEHOLDER_MARKERS):
+            lg("config_sync: STATS_SERVER_URL not configured, skipping.")
+            return
+
+        state = _sync_state()
+        payload = {
+            "config": cfg,
+            "words": _load_json(WORDS_FILE, []),
+            "admin_hash": _admin_hash(),
+            "applied_config_rev": state.get("config_rev", 0),
+            "applied_words_rev": state.get("words_rev", 0),
+            "client_time": datetime.now().isoformat(timespec="seconds"),
+        }
+
+        import requests
+        resp = requests.post(url.rstrip("/") + "/api/sync", json=payload,
+                             timeout=_REQUEST_TIMEOUT,
+                             headers={"Content-Type": "application/json"})
+        if resp.status_code != 200:
+            lg(f"config_sync: server returned {resp.status_code}: {resp.text[:200]}")
+            return
+
+        data = resp.json()
+        new_state = dict(state)
+        applied = []
+
+        cfg_part = data.get("config") or {}
+        if isinstance(cfg_part.get("data"), dict):
+            # Overlay the parent's values onto the current local config rather
+            # than replacing it, so a config key a newer Coalide added locally
+            # (via repair_config) survives and isn't reset on every sync.
+            merged = {**cfg, **cfg_part["data"]}
+            _save_json(CONFIG_FILE, merged)
+            new_state["config_rev"] = cfg_part.get("rev", state.get("config_rev", 0))
+            applied.append("config")
+        elif cfg_part.get("rev"):
+            new_state["config_rev"] = cfg_part["rev"]
+
+        words_part = data.get("words") or {}
+        if isinstance(words_part.get("data"), list):
+            _save_json(WORDS_FILE, words_part["data"])
+            _reconcile_progress(words_part["data"])
+            new_state["words_rev"] = words_part.get("rev", state.get("words_rev", 0))
+            applied.append("words")
+            try:
+                from sm2 import reload_words
+                reload_words()
+            except Exception:
+                pass
+        elif words_part.get("rev"):
+            new_state["words_rev"] = words_part["rev"]
+
+        if new_state != state:
+            _save_json(SYNC_STATE_FILE, new_state)
+        if applied:
+            lg(f"config_sync: applied server changes -> {', '.join(applied)}.")
+    except Exception as e:
+        try:
+            from utils import lg
+            lg(f"config_sync: sync failed: {e}")
+        except Exception:
+            pass
+
+
+def sync_config_async() -> threading.Thread:
+    """Fire-and-forget config/words sync on a daemon thread."""
+    t = threading.Thread(target=_push, name="coalide-config-sync", daemon=True)
+    t.start()
+    return t
+
+
+if __name__ == "__main__":
+    _push()
+    print("Sync attempted (run with -debug in the app to see the log).")

--- a/menu.py
+++ b/menu.py
@@ -28,6 +28,23 @@ except:
     from objects.balance_obj import load_data
     from utils import get_current_user
 
+# Parental stats reporting: pushes the current stats to the parent-side web
+# dashboard/API (serverside/) when the menu opens. Guarded so a missing/broken
+# reporter can never stop the menu from loading.
+try:
+    from stats_reporter import report_stats_async
+except Exception:
+    def report_stats_async():
+        return None
+
+# Config/words sync: pulls parent-made changes from the server and applies them
+# locally when the menu opens. Guarded like the reporter above.
+try:
+    from config_sync import sync_config_async
+except Exception:
+    def sync_config_async():
+        return None
+
 # Path to the external script you want "Quiz" to launch.
 # Change this to wherever your quiz script actually lives.
 APP_PATH = "new_master.py"
@@ -294,6 +311,8 @@ class MainMenu(Screen):
         self.query_one("#stat-balance", Static).update(self._balance_text(user))
         self.query_one("#stat-max", Static).update(self._max_text(user))
         self.query_one("#stat-used", Static).update(self._used_text(user))
+        # A quiz/redeem flow just changed the data — push the update too.
+        report_stats_async()
 
     @staticmethod
     def _random_quote_text() -> str:
@@ -351,6 +370,11 @@ class MainMenu(Screen):
         # Easter egg: a friendly greeting based on the time of day.
         title, message = self._time_greeting()
         self.app.notify(message, title=title, timeout=6)
+
+        # Pull any parent-made config/word changes, then push a fresh stats
+        # snapshot to the parental dashboard (both non-blocking).
+        sync_config_async()
+        report_stats_async()
 
     def on_key(self, event) -> None:
         """Easter eggs: Konami code (↑↑↓↓←→←→ B A) and typed secret words."""

--- a/serverside/.env.example
+++ b/serverside/.env.example
@@ -1,0 +1,23 @@
+# Coalide parental stats server — configuration.
+# Copy this file to ".env" (next to server.py) and fill in your values,
+# or set these as real environment variables. The ".env" file is gitignored.
+
+# --- Telegram daily report ---
+# Create a bot with @BotFather to get the token; get your chat id from @userinfobot.
+TELEGRAM_BOT_TOKEN=123456:ABC-YOUR-BOT-TOKEN
+TELEGRAM_CHAT_ID=123456789
+
+# When to send the daily report (24h local time). Default: midnight.
+COALIDE_REPORT_TIME=00:00
+
+# Turn the daily report on/off explicitly. If omitted, it is ON automatically
+# whenever a bot token and chat id are both set.
+# COALIDE_REPORT_ENABLED=true
+
+# The dashboard link shown at the end of the report. If omitted, it is built
+# from the server host/port. Set this to the address the parent actually uses.
+COALIDE_DASHBOARD_URL=http://192.168.1.50:5055/
+
+# --- Server binding (optional; can also be passed as env vars) ---
+# COALIDE_STATS_HOST=0.0.0.0
+# COALIDE_STATS_PORT=5055

--- a/serverside/.env.example
+++ b/serverside/.env.example
@@ -4,8 +4,10 @@
 
 # --- Telegram daily report ---
 # Create a bot with @BotFather to get the token; get your chat id from @userinfobot.
-TELEGRAM_BOT_TOKEN=123456:ABC-YOUR-BOT-TOKEN
-TELEGRAM_CHAT_ID=123456789
+# Leave these bracketed placeholders as-is to keep the report OFF until you fill
+# them in (the server treats any value starting with "[" as "not configured").
+TELEGRAM_BOT_TOKEN=[YOUR_BOT_TOKEN]
+TELEGRAM_CHAT_ID=[YOUR_CHAT_ID]
 
 # When to send the daily report (24h local time). Default: midnight.
 COALIDE_REPORT_TIME=00:00

--- a/serverside/README.md
+++ b/serverside/README.md
@@ -1,0 +1,137 @@
+# Coalide — Parental Stats Server (`serverside/`)
+
+A small, **zero-dependency** (Python standard library only) server that lets a
+parent watch a learner's Coalide progress from a web browser.
+
+The child's Coalide app pushes a snapshot of its statistics to this server
+every time the main **menu opens** (and after each quiz/redeem flow). The server
+stores the latest snapshot per user and renders it as a web dashboard that shows
+the same information as the in-app **İstatistikler** screen.
+
+> ⚠️ This whole folder is **development/server infrastructure** and never ships
+> in a Coalide release — `python cli.py -release-ready` deletes `serverside/`
+> along with the other local-only artifacts.
+
+## Components
+
+| File | Purpose |
+| --- | --- |
+| `server.py` | HTTP server: stats API, sync API, admin API + serves the pages |
+| `dashboard.html` | The web dashboard (single self-contained page) |
+| `admin.html` | The web admin panel (config + words + server settings) |
+| `report.py` | Daily Telegram report (summary text + dashboard link) |
+| `admin_api.py` | Admin auth + config/words sync backend |
+| `.env.example` | Template for Telegram / report configuration |
+| `data/` | Created at runtime: per-user stats + synced config/words |
+
+## Running it (on the parent's machine)
+
+```bash
+cd serverside
+python server.py
+```
+
+By default it listens on `0.0.0.0:5055`. Override with environment variables:
+
+```bash
+COALIDE_STATS_HOST=127.0.0.1 COALIDE_STATS_PORT=8000 python server.py
+```
+
+Then open the dashboard in a browser:
+
+```
+http://<parent-server-ip>:5055/
+```
+
+## Pointing the child's app at it
+
+In the child's `config.json` (created on first run), set:
+
+```json
+"STATS_REPORTING_ENABLED": true,
+"STATS_SERVER_URL": "http://192.168.1.50:5055"
+```
+
+Reporting is skipped as long as `STATS_SERVER_URL` still contains the shipped
+placeholder (`IP-TO-YOUR-PARENT-SERVER`), so nothing is sent until you set a real
+address. The push runs on a background thread with a short timeout and fails
+silently — it can never slow down or break the learner's app.
+
+## Daily Telegram report
+
+Once a day (at **midnight** by default) the server sends a text summary of every
+learner's stats to a Telegram chat, ending with a link back to the dashboard
+(`🔗 Daha fazla bilgi: <url>`).
+
+Configure it via environment variables or a `.env` file next to `server.py`
+(copy `.env.example` → `.env`). The report turns on automatically once a bot
+token and chat id are set:
+
+```env
+TELEGRAM_BOT_TOKEN=123456:ABC-your-token
+TELEGRAM_CHAT_ID=123456789
+COALIDE_REPORT_TIME=00:00          # 24h local time; default midnight
+COALIDE_DASHBOARD_URL=http://192.168.1.50:5055/
+```
+
+Test it without waiting for midnight:
+
+```bash
+python server.py --report-preview   # print the message, don't send
+python server.py --send-report      # send it right now via Telegram
+```
+
+You can also `GET /api/report/preview` to see the current report text as JSON.
+If the machine is asleep at the scheduled minute, the report still goes out at
+the first moment it is awake at or after that time on a day it hasn't sent yet.
+
+## Web admin — manage Coalide remotely
+
+Because the server runs on a **different device** than Coalide, it can't touch the
+child's files directly. Instead the child's app **syncs** on every menu open: it
+pushes its current `config.json`, `words.json`, and a SHA-256 hash of
+`ADMIN_PASSWORD`, then pulls back any changes you made in the web admin and applies
+them locally (writing the files and reloading, pruning progress for deleted words).
+
+Open the admin from the dashboard's **🛠️ Yönetim** button (or go to `/admin`) and
+log in with the Coalide **admin password** (the same `ADMIN_PASSWORD` from the
+child's `.env`). The password is hashed **in the browser** — only the hash is sent,
+and it is checked against the hash the child synced, so the plaintext password never
+reaches the server. It has two sections:
+
+1. **Coalide Yapılandırması** — edit every `config.json` value (toggles for
+   booleans, typed inputs for the rest) and add / edit / delete words in
+   `words.json`, just like Coalide's built-in admin panel.
+2. **Sunucu (.env) Ayarları** — edit *this* server's own `.env` (Telegram/report
+   settings). Report changes apply within ~30s; host/port changes need a restart.
+
+Edits are versioned: each save bumps a revision number, and the child applies it the
+next time its menu opens. Until a child has synced at least once, the admin shows
+"henüz eşitlenmedi" and login is unavailable (fail-closed).
+
+> ⚠️ Traffic is plain HTTP — fine on a trusted home LAN, but don't expose this
+> server directly to the internet. Put it behind a VPN / reverse proxy with TLS if
+> you need remote access.
+
+## HTTP API
+
+| Method & path | Description |
+| --- | --- |
+| `GET /` | The web dashboard |
+| `GET /api/users` | List users with data and their last-updated times |
+| `GET /api/stats?user=<name>` | Latest stored snapshot for a user (defaults to the most recently updated) |
+| `POST /api/stats` | Store a snapshot. Body: `{ "username", "client_time", "stats" }` |
+| `GET /api/report/preview` | The current daily-report text + whether it is enabled |
+| `POST /api/sync` | Child push/pull of config + words + admin hash (by revision) |
+| `POST /api/admin/login` | Exchange the password hash for a session token |
+| `GET/POST /api/admin/coalide-config` | Read / save the Coalide config (token) |
+| `GET/POST /api/admin/words` | Read / add / edit / delete words (token) |
+| `GET/POST /api/admin/server-env` | Read / save this server's `.env` (token) |
+| `GET /health` | Liveness check |
+
+Admin endpoints require an `X-Admin-Token` header from `/api/admin/login`.
+
+The `stats` payload is exactly what `stats_menu.build_stats()` produces, run
+through a JSON serializer in the client's `stats_reporter.py`. Keeping the
+statistics logic in one place means the dashboard only ever *renders* data — it
+never recomputes it.

--- a/serverside/admin.html
+++ b/serverside/admin.html
@@ -1,0 +1,467 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Coalide — Yönetim</title>
+<style>
+  :root{
+    --bg:#0d0d18; --surface:#16162a; --surface2:#1c1c33; --border:#2a2a45; --grid:#23233c;
+    --purple:#7c5cff; --green:#42d6a4; --yellow:#f5c542; --red:#ff6b81; --blue:#5cc8ff;
+    --ink:#ececf6; --ink2:#b8b8d4; --muted:#8686a8;
+    --shadow:0 1px 3px rgba(0,0,0,.4),0 8px 24px rgba(0,0,0,.28);
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;background:
+      radial-gradient(1200px 600px at 12% -10%,rgba(124,92,255,.10),transparent 60%),
+      radial-gradient(1000px 500px at 100% 0%,rgba(66,214,164,.07),transparent 55%),var(--bg);
+    color:var(--ink);font-family:"Segoe UI",system-ui,-apple-system,Roboto,Arial,sans-serif;
+    font-size:14px;line-height:1.45;min-height:100vh;-webkit-font-smoothing:antialiased;}
+  header{position:sticky;top:0;z-index:20;background:rgba(13,13,24,.85);backdrop-filter:blur(10px);
+    border-bottom:1px solid var(--border);padding:12px 24px;display:flex;align-items:center;gap:16px;flex-wrap:wrap;}
+  .brand{display:flex;align-items:center;gap:11px;}
+  .logo{width:34px;height:34px;border-radius:9px;background:linear-gradient(135deg,var(--purple),#b79bff);
+    display:grid;place-items:center;font-size:18px;box-shadow:0 4px 14px rgba(124,92,255,.4);}
+  .brand .t{font-size:16px;font-weight:700;} .brand .s{font-size:11px;color:var(--muted);margin-top:-2px;}
+  .spacer{flex:1;}
+  a.link{color:var(--blue);text-decoration:none;font-size:13px;} a.link:hover{text-decoration:underline;}
+  select,button,input,textarea{font-family:inherit;}
+  button{background:var(--surface);color:var(--ink);border:1px solid var(--border);border-radius:9px;
+    padding:8px 14px;font-size:13px;cursor:pointer;transition:border-color .15s,background .15s;}
+  button:hover{border-color:var(--purple);} button:active{transform:translateY(1px);}
+  button.primary{background:linear-gradient(135deg,var(--purple),#9a7dff);border-color:transparent;color:#fff;font-weight:600;}
+  button.danger{border-color:var(--red);color:var(--red);} button.danger:hover{background:rgba(255,107,129,.12);}
+  button.ok{border-color:var(--green);color:var(--green);} button.ok:hover{background:rgba(66,214,164,.12);}
+  input[type=text],input[type=number],input[type=password],textarea,select{
+    background:var(--surface);color:var(--ink);border:1px solid var(--border);border-radius:8px;padding:8px 10px;font-size:13px;width:100%;}
+  textarea{min-height:64px;resize:vertical;font-family:ui-monospace,Consolas,monospace;}
+  main{max-width:1100px;margin:0 auto;padding:22px 24px 60px;}
+
+  /* login */
+  .login-wrap{max-width:420px;margin:9vh auto;}
+  .card{background:linear-gradient(180deg,var(--surface),var(--surface2));border:1px solid var(--border);
+    border-radius:16px;padding:22px 24px;box-shadow:var(--shadow);}
+  .card h2{margin:0 0 6px;font-size:17px;} .card .sub{color:var(--muted);font-size:13px;margin-bottom:16px;}
+  .msg{margin-top:12px;font-size:13px;min-height:18px;}
+  .msg.err{color:var(--red);} .msg.okc{color:var(--green);}
+
+  .tabs{display:flex;gap:8px;margin-bottom:20px;flex-wrap:wrap;}
+  .tab{padding:9px 16px;border-radius:999px;border:1px solid var(--border);background:var(--surface);
+    color:var(--ink2);cursor:pointer;font-size:13px;font-weight:600;}
+  .tab.active{color:#fff;background:linear-gradient(135deg,var(--purple),#9a7dff);border-color:transparent;box-shadow:0 4px 14px rgba(124,92,255,.35);}
+  section.page{display:none;} section.page.active{display:block;}
+
+  .panel{background:linear-gradient(180deg,var(--surface),var(--surface2));border:1px solid var(--border);
+    border-radius:16px;padding:18px 20px;box-shadow:var(--shadow);margin-bottom:18px;}
+  .panel h3{margin:0 0 4px;font-size:15px;} .panel .desc{color:var(--muted);font-size:12.5px;margin-bottom:14px;}
+  .toolbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:14px;}
+  .toolbar .spacer{flex:1;}
+
+  .cfg-row{display:grid;grid-template-columns:1fr 320px;gap:14px;align-items:center;
+    padding:12px 0;border-bottom:1px solid var(--grid);}
+  .cfg-row:last-of-type{border-bottom:0;}
+  .cfg-row .k{font-weight:700;} .cfg-row .d{color:var(--muted);font-size:12px;margin-top:2px;}
+  @media(max-width:720px){.cfg-row{grid-template-columns:1fr;}}
+
+  /* toggle */
+  .toggle{position:relative;display:inline-block;width:46px;height:26px;}
+  .toggle input{display:none;}
+  .toggle .sl{position:absolute;inset:0;background:var(--grid);border-radius:999px;transition:.15s;border:1px solid var(--border);}
+  .toggle .sl::before{content:"";position:absolute;width:18px;height:18px;left:3px;top:3px;background:var(--ink2);border-radius:50%;transition:.15s;}
+  .toggle input:checked + .sl{background:var(--green);}
+  .toggle input:checked + .sl::before{transform:translateX(20px);background:#08120d;}
+
+  table{width:100%;border-collapse:collapse;font-size:13px;}
+  th,td{padding:8px 10px;text-align:left;border-bottom:1px solid var(--grid);}
+  thead th{position:sticky;top:0;background:var(--surface2);color:var(--muted);z-index:1;}
+  tbody tr:hover{background:rgba(124,92,255,.06);}
+  .table-wrap{max-height:60vh;overflow:auto;border:1px solid var(--border);border-radius:12px;}
+  .rowbtns{display:flex;gap:6px;} .rowbtns button{padding:4px 9px;font-size:12px;}
+  .count{color:var(--muted);font-size:12.5px;}
+
+  /* modal */
+  .overlay{position:fixed;inset:0;background:rgba(6,6,14,.72);display:none;align-items:center;justify-content:center;z-index:50;padding:20px;}
+  .overlay.show{display:flex;}
+  .modal{background:linear-gradient(180deg,var(--surface),var(--surface2));border:1px solid var(--purple);
+    border-radius:16px;padding:20px 22px;width:560px;max-width:100%;max-height:90vh;overflow:auto;box-shadow:var(--shadow);}
+  .modal h3{margin:0 0 14px;} .field{margin-bottom:12px;} .field label{display:block;color:var(--muted);font-size:12px;margin-bottom:5px;}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
+  .modal-btns{display:flex;justify-content:flex-end;gap:10px;margin-top:16px;}
+
+  #toast{position:fixed;right:20px;bottom:20px;z-index:100;display:flex;flex-direction:column;gap:8px;}
+  .tmsg{background:var(--surface2);border:1px solid var(--border);border-left:4px solid var(--green);
+    border-radius:10px;padding:10px 14px;box-shadow:var(--shadow);font-size:13px;opacity:0;transform:translateY(8px);
+    transition:.2s;max-width:340px;}
+  .tmsg.show{opacity:1;transform:none;} .tmsg.err{border-left-color:var(--red);}
+  .empty{color:var(--muted);font-style:italic;padding:16px 0;}
+</style>
+</head>
+<body>
+<header>
+  <div class="brand"><div class="logo">🛠️</div><div><div class="t">COALIDE</div><div class="s">Yönetim Paneli</div></div></div>
+  <div class="spacer"></div>
+  <a class="link" href="/">← Panele dön</a>
+  <button id="logout" style="display:none">🚪 Çıkış</button>
+</header>
+
+<main>
+  <!-- LOGIN -->
+  <div class="login-wrap" id="login">
+    <div class="card">
+      <h2>🔒 Admin Girişi</h2>
+      <div class="sub">Devam etmek için Coalide admin şifresini girin.</div>
+      <input type="password" id="pw" placeholder="Admin şifresi" autocomplete="current-password">
+      <div style="margin-top:12px"><button class="primary" id="login-btn" style="width:100%">Giriş Yap</button></div>
+      <div class="msg" id="login-msg"></div>
+    </div>
+  </div>
+
+  <!-- APP -->
+  <div id="app" style="display:none">
+    <div class="tabs">
+      <div class="tab active" data-tab="coalide">🎛️ Coalide Yapılandırması</div>
+      <div class="tab" data-tab="server">🖥️ Sunucu (.env) Ayarları</div>
+    </div>
+
+    <section class="page active" data-page="coalide">
+      <div class="panel" id="cfg-panel">
+        <h3>⚙️ Coalide Ayarları (config.json)</h3>
+        <div class="desc">Değişiklikler sunucuda saklanır ve çocuğun cihazı menüyü bir sonraki açtığında uygulanır.</div>
+        <div id="cfg-body"><div class="empty">Yükleniyor…</div></div>
+        <div class="toolbar" style="margin-top:16px;margin-bottom:0">
+          <span class="count" id="cfg-rev"></span><div class="spacer"></div>
+          <button class="primary" id="cfg-save">💾 Ayarları Kaydet</button>
+        </div>
+      </div>
+
+      <div class="panel" id="words-panel">
+        <h3>🔤 Kelimeler (words.json)</h3>
+        <div class="desc">Kelime ekleyin, düzenleyin veya silin. Silinen kelimenin ilerleme kaydı çocuğun cihazında temizlenir.</div>
+        <div class="toolbar">
+          <input type="text" id="word-search" placeholder="🔍 Kelime ara…" style="max-width:280px">
+          <span class="count" id="word-count"></span>
+          <div class="spacer"></div>
+          <button class="ok" id="word-add">➕ Kelime Ekle</button>
+        </div>
+        <div id="words-body"><div class="empty">Yükleniyor…</div></div>
+      </div>
+    </section>
+
+    <section class="page" data-page="server">
+      <div class="panel">
+        <h3>🖥️ Sunucu Yapılandırması (.env)</h3>
+        <div class="desc">Bu sunucunun kendi ayarları (Telegram raporu vb.). Rapor ayarları anında geçerli olur;
+          host/port değişikliği için sunucuyu yeniden başlatın.</div>
+        <div id="env-body"><div class="empty">Yükleniyor…</div></div>
+        <div class="toolbar" style="margin-top:14px;margin-bottom:0">
+          <button id="env-add-key">➕ Anahtar Ekle</button>
+          <div class="spacer"></div>
+          <button class="primary" id="env-save">💾 Kaydet</button>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>
+
+<!-- word modal -->
+<div class="overlay" id="word-overlay">
+  <div class="modal">
+    <h3 id="word-modal-title">Kelime</h3>
+    <input type="hidden" id="w-index">
+    <div class="field"><label>Hedef kelime (öğrenilen dilde) *</label><input type="text" id="w-target" placeholder="örn. run"></div>
+    <div class="field"><label>Anlamları — virgülle ayırın (kaynak dilde) *</label><input type="text" id="w-source" placeholder="örn. koşmak, kaçmak"></div>
+    <div class="two">
+      <div class="field"><label>Kelime türü</label><select id="w-type"></select></div>
+      <div class="field"><label>Dil kodu (ISO 639)</label><input type="text" id="w-lang" placeholder="en"></div>
+    </div>
+    <div class="two">
+      <div class="field"><label>Cümle — boşluktan ÖNCE</label><input type="text" id="w-s1" placeholder="He can"></div>
+      <div class="field"><label>Cümle — boşluktan SONRA</label><input type="text" id="w-s2" placeholder="very fast"></div>
+    </div>
+    <div class="two">
+      <div class="field"><label>Geçmiş zaman (V2) — fiiller için</label><input type="text" id="w-past" placeholder="ran"></div>
+      <div class="field"><label>Üçüncü hâl (V3) — fiiller için</label><input type="text" id="w-v3" placeholder="run"></div>
+    </div>
+    <div class="modal-btns">
+      <button id="w-cancel">İptal</button>
+      <button class="primary" id="w-save">💾 Kaydet</button>
+    </div>
+  </div>
+</div>
+<div id="toast"></div>
+
+<script>
+"use strict";
+// ---- compact SHA-256 (geraintluff, public domain) — needed because
+// crypto.subtle is unavailable over plain http on a LAN IP ----
+function sha256(ascii){
+  function rr(v,a){return (v>>>a)|(v<<(32-a));}
+  var mp=Math.pow,mw=mp(2,32),i,j,result='';
+  var words=[],bl=ascii.length*8;
+  var h=sha256.h=sha256.h||[],k=sha256.k=sha256.k||[],pc=k.length,comp={};
+  for(var c=2;pc<64;c++){ if(!comp[c]){ for(i=0;i<313;i+=c)comp[i]=c;
+      h[pc]=(mp(c,.5)*mw)|0; k[pc++]=(mp(c,1/3)*mw)|0; } }
+  ascii+='\x80'; while(ascii.length%64-56)ascii+='\x00';
+  for(i=0;i<ascii.length;i++){ j=ascii.charCodeAt(i); if(j>>8)return; words[i>>2]|=j<<((3-i)%4)*8; }
+  words[words.length]=(bl/mw)|0; words[words.length]=bl;
+  for(j=0;j<words.length;){
+    var w=words.slice(j,j+=16),oh=h; h=h.slice(0,8);
+    for(i=0;i<64;i++){
+      var w15=w[i-15],w2=w[i-2],a=h[0],e=h[4];
+      var t1=h[7]+(rr(e,6)^rr(e,11)^rr(e,25))+((e&h[5])^((~e)&h[6]))+k[i]
+        +(w[i]=(i<16)?w[i]:(w[i-16]+(rr(w15,7)^rr(w15,18)^(w15>>>3))+w[i-7]
+        +(rr(w2,17)^rr(w2,19)^(w2>>>10)))|0);
+      var t2=(rr(a,2)^rr(a,13)^rr(a,22))+((a&h[1])^(a&h[2])^(h[1]&h[2]));
+      h=[(t1+t2)|0].concat(h); h[4]=(h[4]+t1)|0;
+    }
+    for(i=0;i<8;i++)h[i]=(h[i]+oh[i])|0;
+  }
+  for(i=0;i<8;i++)for(j=3;j+1;j--){var b=(h[i]>>(j*8))&255;result+=((b<16)?0:'')+b.toString(16);}
+  return result;
+}
+function hashPw(pw){ return sha256(unescape(encodeURIComponent(pw))); }
+
+const WORD_TYPES=["noun","verb","adjective","adverb","pronoun","preposition","other"];
+let TOKEN=sessionStorage.getItem('coalide_admin_token')||null;
+let CONFIG_ORIG={}, WORDS=[], WORDS_REV=0;
+
+function $(id){return document.getElementById(id);}
+function esc(s){return String(s==null?"":s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));}
+function toast(msg,isErr){
+  const t=document.createElement('div'); t.className='tmsg'+(isErr?' err':''); t.textContent=msg;
+  $('toast').appendChild(t); requestAnimationFrame(()=>t.classList.add('show'));
+  setTimeout(()=>{t.classList.remove('show');setTimeout(()=>t.remove(),250);},3600);
+}
+async function api(path,{method="GET",body=null}={}){
+  const opt={method,headers:{}};
+  if(TOKEN)opt.headers['X-Admin-Token']=TOKEN;
+  if(body){opt.headers['Content-Type']='application/json';opt.body=JSON.stringify(body);}
+  const res=await fetch(path,opt);
+  if(res.status===401){ logout(); throw new Error("Oturum sona erdi, tekrar giriş yapın."); }
+  const data=await res.json().catch(()=>({}));
+  if(!res.ok)throw new Error(data.error||res.statusText);
+  return data;
+}
+
+// ---- auth ----
+async function doLogin(){
+  const pw=$('pw').value;
+  const msg=$('login-msg'); msg.className='msg'; msg.textContent='';
+  if(!pw){msg.className='msg err';msg.textContent='Şifre girin.';return;}
+  try{
+    const data=await api('/api/admin/login',{method:'POST',body:{hash:hashPw(pw)}});
+    TOKEN=data.token; sessionStorage.setItem('coalide_admin_token',TOKEN);
+    showApp();
+  }catch(e){
+    msg.className='msg err';
+    msg.textContent = /not_synced/.test(e.message)
+      ? "Çocuğun cihazı henüz sunucuyla eşitlenmedi. Uygulamada menüyü bir kez açın."
+      : "Yanlış şifre.";
+    $('pw').value='';
+  }
+}
+function logout(){
+  if(TOKEN){ api('/api/admin/logout',{method:'POST'}).catch(()=>{}); }
+  TOKEN=null; sessionStorage.removeItem('coalide_admin_token');
+  $('app').style.display='none'; $('logout').style.display='none'; $('login').style.display='block';
+}
+function showApp(){
+  $('login').style.display='none'; $('app').style.display='block'; $('logout').style.display='inline-block';
+  loadConfig(); loadWords(); loadEnv();
+}
+
+// ---- config editor ----
+async function loadConfig(){
+  const body=$('cfg-body');
+  try{
+    const d=await api('/api/admin/coalide-config');
+    if(!d.synced){ body.innerHTML='<div class="empty">Çocuğun cihazı henüz eşitlenmedi — ayarlar uygulamada menü açılınca görünür.</div>'; $('cfg-rev').textContent=''; return; }
+    CONFIG_ORIG=d.config||{}; $('cfg-rev').textContent='Sürüm '+d.rev+(d.updated_at?' · '+new Date(d.updated_at).toLocaleString('tr-TR'):'');
+    body.innerHTML='';
+    for(const [key,val] of Object.entries(CONFIG_ORIG)){
+      const row=document.createElement('div'); row.className='cfg-row';
+      const left=document.createElement('div');
+      left.innerHTML='<div class="k">'+esc(key)+'</div>'+(d.descriptions[key]?'<div class="d">'+esc(d.descriptions[key])+'</div>':'');
+      const right=document.createElement('div');
+      right.appendChild(cfgInput(key,val));
+      row.appendChild(left); row.appendChild(right); body.appendChild(row);
+    }
+  }catch(e){ body.innerHTML='<div class="empty">Yüklenemedi: '+esc(e.message)+'</div>'; }
+}
+function cfgInput(key,val){
+  if(typeof val==='boolean'){
+    const l=document.createElement('label'); l.className='toggle';
+    l.innerHTML='<input type="checkbox" data-k="'+esc(key)+'" data-t="bool"'+(val?' checked':'')+'><span class="sl"></span>';
+    return l;
+  }
+  if(typeof val==='number'){
+    const i=document.createElement('input'); i.type='number'; i.step='any'; i.value=val; i.dataset.k=key; i.dataset.t='number'; return i;
+  }
+  if(typeof val==='string'){
+    const i=document.createElement('input'); i.type='text'; i.value=val; i.dataset.k=key; i.dataset.t='string'; return i;
+  }
+  const t=document.createElement('textarea'); t.value=JSON.stringify(val,null,0); t.dataset.k=key; t.dataset.t='json'; return t;
+}
+async function saveConfig(){
+  const out={}; let bad=null;
+  document.querySelectorAll('#cfg-body [data-k]').forEach(el=>{
+    if(bad)return; const key=el.dataset.k, t=el.dataset.t;
+    if(t==='bool')out[key]=el.checked;
+    else if(t==='number'){const n=parseFloat(el.value);if(isNaN(n)){bad=key;return;}out[key]=Number.isInteger(n)&&!/[.eE]/.test(el.value)?parseInt(el.value,10):n;}
+    else if(t==='string')out[key]=el.value;
+    else{try{out[key]=JSON.parse(el.value);}catch(_){bad=key;}}
+  });
+  if(bad){toast("'"+bad+"' için geçersiz değer.",true);return;}
+  try{const d=await api('/api/admin/coalide-config',{method:'POST',body:{config:out}});
+    CONFIG_ORIG=out; $('cfg-rev').textContent='Sürüm '+d.rev+' · az önce kaydedildi';
+    toast('Ayarlar kaydedildi. Çocuğun cihazına bir sonraki menü açılışında uygulanacak.');
+  }catch(e){toast('Kaydedilemedi: '+e.message,true);}
+}
+
+// ---- words ----
+async function loadWords(){
+  const body=$('words-body');
+  try{
+    const d=await api('/api/admin/words');
+    if(!d.synced){ body.innerHTML='<div class="empty">Çocuğun cihazı henüz eşitlenmedi.</div>'; $('word-count').textContent=''; return; }
+    WORDS=d.words||[]; WORDS_REV=d.rev; renderWords();
+  }catch(e){ body.innerHTML='<div class="empty">Yüklenemedi: '+esc(e.message)+'</div>'; }
+}
+function renderWords(){
+  const q=($('word-search').value||'').trim().toLowerCase();
+  const body=$('words-body');
+  const rows=WORDS.map((w,i)=>({w,i})).filter(({w})=>{
+    if(!q)return true;
+    return (w.target||'').toLowerCase().includes(q) || (w.source||[]).join(',').toLowerCase().includes(q);
+  });
+  $('word-count').textContent=WORDS.length+' kelime'+(q?(' · '+rows.length+' eşleşme'):'');
+  if(!WORDS.length){body.innerHTML='<div class="empty">Kayıtlı kelime yok.</div>';return;}
+  const wrap=document.createElement('div'); wrap.className='table-wrap';
+  const tbl=document.createElement('table');
+  tbl.innerHTML='<thead><tr><th>Hedef</th><th>Anlam</th><th>Tür</th><th>Cümle</th><th>V2</th><th>V3</th><th></th></tr></thead>';
+  const tb=document.createElement('tbody');
+  for(const {w,i} of rows){
+    const s=(w.sentence||['','']); const sent=((s[0]||'')+' ___ '+(s[1]||'')).trim();
+    const tr=document.createElement('tr');
+    tr.innerHTML='<td><b>'+esc(w.target)+'</b></td><td style="color:var(--green)">'+esc((w.source||[]).join(', '))+
+      '</td><td style="color:var(--purple)">'+esc(w.word_type||'')+'</td><td style="color:var(--muted)">'+esc(sent)+
+      '</td><td>'+esc(w.past||'')+'</td><td>'+esc(w.v3||'')+'</td>';
+    const td=document.createElement('td');
+    const btns=document.createElement('div'); btns.className='rowbtns';
+    const eb=document.createElement('button'); eb.textContent='✏️'; eb.title='Düzenle'; eb.onclick=()=>openWordModal(i);
+    const db=document.createElement('button'); db.className='danger'; db.textContent='🗑'; db.title='Sil'; db.onclick=()=>deleteWord(i,w.target);
+    btns.appendChild(eb); btns.appendChild(db); td.appendChild(btns); tr.appendChild(td);
+    tb.appendChild(tr);
+  }
+  tbl.appendChild(tb); wrap.appendChild(tbl); body.innerHTML=''; body.appendChild(wrap);
+}
+function openWordModal(index){
+  const editing=index!=null && index>=0;
+  const w=editing?WORDS[index]:{};
+  $('word-modal-title').textContent=editing?'✏️ Kelimeyi Düzenle':'➕ Yeni Kelime';
+  $('w-index').value=editing?index:'';
+  $('w-target').value=w.target||''; $('w-source').value=(w.source||[]).join(', ');
+  $('w-lang').value=w.language||'en';
+  const s=(w.sentence||['','']); $('w-s1').value=s[0]||''; $('w-s2').value=s[1]||'';
+  $('w-past').value=w.past||''; $('w-v3').value=w.v3||'';
+  const sel=$('w-type'); sel.innerHTML='';
+  const cur=(w.word_type||'noun').toLowerCase(); const types=[...WORD_TYPES]; if(!types.includes(cur))types.push(cur);
+  types.forEach(t=>{const o=document.createElement('option');o.value=t;o.textContent=t;if(t===cur)o.selected=true;sel.appendChild(o);});
+  $('word-overlay').classList.add('show');
+}
+function closeWordModal(){$('word-overlay').classList.remove('show');}
+async function saveWord(){
+  const idx=$('w-index').value;
+  const word={
+    target:$('w-target').value.trim(),
+    source:$('w-source').value,
+    word_type:$('w-type').value,
+    language:$('w-lang').value.trim()||'en',
+    sentence:[$('w-s1').value.trim(),$('w-s2').value.trim()],
+    past:$('w-past').value.trim(), v3:$('w-v3').value.trim(),
+  };
+  if(!word.target){toast('Hedef kelime boş olamaz.',true);return;}
+  const isEdit=idx!=='';
+  try{
+    const d=await api('/api/admin/words',{method:'POST',body:isEdit?{action:'edit',index:parseInt(idx,10),word}:{action:'add',word}});
+    closeWordModal(); toast((isEdit?"'"+d.target+"' güncellendi.":"'"+d.target+"' eklendi.")+' Toplam '+d.count+' kelime.');
+    await loadWords();
+  }catch(e){toast('Kaydedilemedi: '+e.message,true);}
+}
+async function deleteWord(index,target){
+  if(!confirm("'"+target+"' silinsin mi? İlerleme kaydı da çocuğun cihazında temizlenir."))return;
+  try{const d=await api('/api/admin/words',{method:'POST',body:{action:'delete',index}});
+    toast("'"+d.target+"' silindi. Kalan: "+d.count+" kelime."); await loadWords();
+  }catch(e){toast('Silinemedi: '+e.message,true);}
+}
+
+// ---- server env ----
+const ENV_LABELS={
+  TELEGRAM_BOT_TOKEN:['Telegram Bot Token','password'],
+  TELEGRAM_CHAT_ID:['Telegram Chat ID','text'],
+  COALIDE_REPORT_TIME:['Günlük rapor saati (SS:DD)','text'],
+  COALIDE_REPORT_ENABLED:['Rapor açık mı (true/false)','text'],
+  COALIDE_DASHBOARD_URL:['Panel adresi (rapor linki)','text'],
+  COALIDE_STATS_HOST:['Sunucu host (yeniden başlatma gerekir)','text'],
+  COALIDE_STATS_PORT:['Sunucu port (yeniden başlatma gerekir)','text'],
+};
+async function loadEnv(){
+  const body=$('env-body');
+  try{
+    const d=await api('/api/admin/server-env');
+    const env=d.env||{}, known=d.known||[];
+    const keys=[...known, ...Object.keys(env).filter(k=>!known.includes(k))];
+    body.innerHTML='';
+    keys.forEach(k=>body.appendChild(envRow(k,env[k]!=null?env[k]:'')));
+    if(!keys.length)body.innerHTML='<div class="empty">Anahtar yok.</div>';
+  }catch(e){ body.innerHTML='<div class="empty">Yüklenemedi: '+esc(e.message)+'</div>'; }
+}
+function envRow(key,val){
+  const [label,type]=ENV_LABELS[key]||[key,'text'];
+  const row=document.createElement('div'); row.className='cfg-row';
+  const left=document.createElement('div');
+  left.innerHTML='<div class="k">'+esc(key)+'</div>'+(ENV_LABELS[key]?'<div class="d">'+esc(label)+'</div>':'');
+  const right=document.createElement('div'); right.style.display='flex'; right.style.gap='8px';
+  const inp=document.createElement('input'); inp.type=type; inp.value=val; inp.dataset.envk=key; inp.style.flex='1';
+  right.appendChild(inp);
+  if(!(key in ENV_LABELS)){
+    const rm=document.createElement('button'); rm.className='danger'; rm.textContent='✕'; rm.title='Kaldır';
+    rm.onclick=()=>row.remove(); right.appendChild(rm);
+  }
+  row.appendChild(left); row.appendChild(right); return row;
+}
+function addEnvKey(){
+  const key=prompt('Yeni anahtar adı (A-Z, 0-9, _):'); if(!key)return;
+  if(!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)){toast('Geçersiz anahtar adı.',true);return;}
+  $('env-body').appendChild(envRow(key,''));
+}
+async function saveEnv(){
+  const env={};
+  document.querySelectorAll('#env-body [data-envk]').forEach(el=>{ env[el.dataset.envk]=el.value; });
+  try{await api('/api/admin/server-env',{method:'POST',body:{env}});
+    toast('Sunucu ayarları kaydedildi.');
+  }catch(e){toast('Kaydedilemedi: '+e.message,true);}
+}
+
+// ---- wire up ----
+$('login-btn').onclick=doLogin;
+$('pw').addEventListener('keydown',e=>{if(e.key==='Enter')doLogin();});
+$('logout').onclick=logout;
+$('cfg-save').onclick=saveConfig;
+$('word-add').onclick=()=>openWordModal(null);
+$('word-search').addEventListener('input',renderWords);
+$('w-cancel').onclick=closeWordModal;
+$('w-save').onclick=saveWord;
+$('word-overlay').addEventListener('click',e=>{if(e.target===$('word-overlay'))closeWordModal();});
+$('env-add-key').onclick=addEnvKey;
+$('env-save').onclick=saveEnv;
+document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
+  document.querySelectorAll('.tab').forEach(x=>x.classList.toggle('active',x===t));
+  document.querySelectorAll('section.page').forEach(p=>p.classList.toggle('active',p.dataset.page===t.dataset.tab));
+});
+
+// If we already hold a token, try to use it; otherwise show login.
+if(TOKEN){ api('/api/admin/coalide-config').then(()=>showApp()).catch(()=>logout()); }
+</script>
+</body>
+</html>

--- a/serverside/admin_api.py
+++ b/serverside/admin_api.py
@@ -1,0 +1,353 @@
+"""
+Coalide — admin & sync backend (server side).
+
+The stats server runs on a DIFFERENT device than Coalide, so it has no direct
+access to the child's config.json / words.json / .env. Instead everything flows
+over HTTP:
+
+  * The child app, when its menu opens, calls POST /api/sync — it pushes its
+    current config + words + a hash of ADMIN_PASSWORD, and pulls back any
+    changes the parent has made (by comparing revision numbers).
+  * The parent edits the server-held authoritative copy through the web admin
+    (/admin), gated behind the same admin password (verified against the hash
+    the child synced — the plaintext password never reaches the server).
+
+Authoritative state lives in DATA_DIR:
+    coalide_config.json   {"rev", "updated_at", "data": {...}}
+    coalide_words.json    {"rev", "updated_at", "data": [...]}
+    admin.json            {"hash", "updated_at"}
+
+The serverside's OWN .env (Telegram/report settings) is a real local file on
+this device and is edited directly.
+
+Stdlib only.
+"""
+
+import hmac
+import json
+import os
+import re
+import secrets
+import threading
+import time
+from datetime import datetime, timezone
+
+from report import _parse_env_file  # reuse the tiny .env parser
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+CONFIG_FILE = os.path.join(DATA_DIR, "coalide_config.json")
+WORDS_FILE = os.path.join(DATA_DIR, "coalide_words.json")
+ADMIN_FILE = os.path.join(DATA_DIR, "admin.json")
+SERVER_ENV = os.path.join(BASE_DIR, ".env")
+
+SESSION_TTL = 2 * 3600  # seconds
+_sessions = {}          # token -> expiry timestamp
+_lock = threading.RLock()
+
+WORD_TYPES = ["noun", "verb", "adjective", "adverb", "pronoun", "preposition", "other"]
+
+# Parent-friendly descriptions for config.json keys (mirrors admin.py).
+CONFIG_DESCRIPTIONS = {
+    "Daily_New_Word_Cap": "Bir günde en fazla kaç yeni kelime tanıtılır.",
+    "No_Repeat_Window": "Aynı kelime tekrar sorulmadan önce kaç soru geçmeli.",
+    "Repo_Owner": "Güncellemelerin indirildiği GitHub kullanıcısı.",
+    "Repo_Name": "Güncellemelerin indirildiği GitHub deposu.",
+    "Update_Prereleases": "Ön sürüm (beta) güncellemeleri de yüklensin mi.",
+    "Source_Language": "Kaynak dil (çocuğun bildiği dil).",
+    "Target_Language": "Hedef dil (öğrenilen dil).",
+    "BASE_RATE_PER_MINUTE": "1 dakika ekran süresinin taban kredi fiyatı.",
+    "ESCALATION_PER_HOUR": "Aynı gün alınan her ek saatte fiyat artış oranı (0.5 = %50).",
+    "SPAM_PROTECTION": "Art arda rastgele cevap yazmayı engelle.",
+    "INPUT_TIMEOUT": "Cevap için süre sınırı, saniye (0 = kapalı).",
+    "Credit_Reset_Weekly": "Krediler her Pazartesi sıfırlansın mı.",
+    "BACKUP_PRONUNCIATIONS": "Telaffuz ses dosyalarını yedekle.",
+    "KIOSK_MODE": "Kiosk modu: uygulama kapanınca otomatik yeniden açılır.",
+    "BYPASS_SHORTCUTS": "Alt+Tab / Windows tuşu gibi kaçış kısayollarını engelle.",
+    "Credit_Window_Start": "Kredi kazanmanın başladığı saat (SS:DD, örn. 07:00).",
+    "Credit_Window_End": "Kredi kazanmanın bittiği saat (SS:DD, örn. 22:00).",
+    "REQUIRE_INTERNET": "İnternet yoksa quiz başlatılmasın.",
+    "STATS_REPORTING_ENABLED": "İstatistikleri veli sunucusuna gönder.",
+    "STATS_SERVER_URL": "Veli sunucusunun adresi (istatistik ve senkronizasyon).",
+    "CONFIG_SYNC_ENABLED": "Ayar/kelime değişikliklerini sunucudan çek ve uygula.",
+}
+
+# Keys the serverside .env editor surfaces with friendly labels (extras allowed).
+SERVER_ENV_KEYS = [
+    "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID", "COALIDE_REPORT_TIME",
+    "COALIDE_REPORT_ENABLED", "COALIDE_DASHBOARD_URL",
+    "COALIDE_STATS_HOST", "COALIDE_STATS_PORT",
+]
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+# --------------------------------------------------------------------------
+# JSON store helpers
+# --------------------------------------------------------------------------
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _load(path, fallback):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return fallback
+
+
+def _save(path, data) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+# --------------------------------------------------------------------------
+# Sync (child <-> server)
+# --------------------------------------------------------------------------
+
+def sync(payload: dict) -> dict:
+    """Handle a child's push/pull. Seeds authoritative state on first contact,
+    stores the admin hash, and returns whatever the parent has since changed."""
+    with _lock:
+        resp = {}
+
+        # Admin password hash — always refresh from the child (source of truth).
+        h = payload.get("admin_hash")
+        if isinstance(h, str) and h:
+            _save(ADMIN_FILE, {"hash": h.lower(), "updated_at": _now()})
+
+        # Config
+        cfg = _load(CONFIG_FILE, None)
+        if cfg is None and isinstance(payload.get("config"), dict):
+            cfg = {"rev": 1, "updated_at": _now(), "data": payload["config"]}
+            _save(CONFIG_FILE, cfg)
+        if cfg is None:
+            resp["config"] = {"rev": 0, "data": None}
+        else:
+            applied = _int(payload.get("applied_config_rev"))
+            resp["config"] = {"rev": cfg["rev"],
+                              "data": cfg["data"] if cfg["rev"] > applied else None}
+
+        # Words
+        w = _load(WORDS_FILE, None)
+        if w is None and isinstance(payload.get("words"), list):
+            w = {"rev": 1, "updated_at": _now(), "data": payload["words"]}
+            _save(WORDS_FILE, w)
+        if w is None:
+            resp["words"] = {"rev": 0, "data": None}
+        else:
+            applied = _int(payload.get("applied_words_rev"))
+            resp["words"] = {"rev": w["rev"],
+                            "data": w["data"] if w["rev"] > applied else None}
+
+        return resp
+
+
+def _int(v) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+# --------------------------------------------------------------------------
+# Authentication
+# --------------------------------------------------------------------------
+
+def stored_admin_hash():
+    a = _load(ADMIN_FILE, {})
+    return a.get("hash") if isinstance(a, dict) else None
+
+
+def login(received_hash: str):
+    """Verify a hex SHA-256 of the admin password against the synced hash.
+    Returns (token, None) on success or (None, reason)."""
+    with _lock:
+        stored = stored_admin_hash()
+        if not stored:
+            return None, "not_synced"
+        if not received_hash or not hmac.compare_digest(
+                str(received_hash).strip().lower(), str(stored).strip().lower()):
+            return None, "bad_password"
+        token = secrets.token_urlsafe(32)
+        _sessions[token] = time.time() + SESSION_TTL
+        return token, None
+
+
+def valid_token(token: str) -> bool:
+    if not token:
+        return False
+    with _lock:
+        exp = _sessions.get(token)
+        if not exp:
+            return False
+        if exp < time.time():
+            _sessions.pop(token, None)
+            return False
+        _sessions[token] = time.time() + SESSION_TTL  # sliding expiry
+        return True
+
+
+def logout(token: str) -> None:
+    with _lock:
+        _sessions.pop(token, None)
+
+
+# --------------------------------------------------------------------------
+# Coalide config (authoritative, parent-editable)
+# --------------------------------------------------------------------------
+
+def get_config_state() -> dict:
+    cfg = _load(CONFIG_FILE, None)
+    return {
+        "synced": cfg is not None,
+        "rev": cfg["rev"] if cfg else 0,
+        "updated_at": cfg["updated_at"] if cfg else None,
+        "config": cfg["data"] if cfg else {},
+        "descriptions": CONFIG_DESCRIPTIONS,
+    }
+
+
+def save_config(data: dict) -> int:
+    if not isinstance(data, dict):
+        raise ValueError("config must be a JSON object")
+    with _lock:
+        cur = _load(CONFIG_FILE, None)
+        rev = (cur["rev"] + 1) if cur else 1
+        _save(CONFIG_FILE, {"rev": rev, "updated_at": _now(), "data": data})
+        return rev
+
+
+# --------------------------------------------------------------------------
+# Coalide words (authoritative, parent-editable)
+# --------------------------------------------------------------------------
+
+def get_words_state() -> dict:
+    w = _load(WORDS_FILE, None)
+    return {"synced": w is not None, "rev": w["rev"] if w else 0,
+            "words": w["data"] if w else []}
+
+
+def _words_data():
+    w = _load(WORDS_FILE, None)
+    if w is None:
+        raise ValueError("Kelime listesi henüz eşitlenmedi.")
+    return w, list(w["data"] if isinstance(w.get("data"), list) else [])
+
+
+def _bump_words(data: list) -> int:
+    cur = _load(WORDS_FILE, None)
+    rev = (cur["rev"] + 1) if cur else 1
+    _save(WORDS_FILE, {"rev": rev, "updated_at": _now(), "data": data})
+    return rev
+
+
+def _norm_word(raw: dict, existing: dict | None = None) -> dict:
+    if not isinstance(raw, dict):
+        raise ValueError("Geçersiz kelime verisi.")
+    target = str(raw.get("target", "")).strip()
+    if not target:
+        raise ValueError("Hedef kelime boş olamaz.")
+    source = raw.get("source")
+    if isinstance(source, str):
+        source = [p.strip() for p in source.split(",") if p.strip()]
+    source = [str(x).strip() for x in (source or []) if str(x).strip()]
+    if not source:
+        raise ValueError("En az bir anlam girmelisiniz.")
+    sentence = raw.get("sentence") or ["", ""]
+    if not isinstance(sentence, (list, tuple)):
+        sentence = ["", ""]
+    s1 = str(sentence[0]) if len(sentence) > 0 else ""
+    s2 = str(sentence[1]) if len(sentence) > 1 else ""
+    return {
+        "language": str(raw.get("language") or "en").strip() or "en",
+        "word_type": str(raw.get("word_type") or "noun").strip().lower(),
+        "sentence": [s1, s2],
+        "target": target,
+        "past": str(raw.get("past") or "").strip(),
+        "v3": str(raw.get("v3") or "").strip(),
+        "source": source,
+        "next_review_date": (existing or {}).get("next_review_date"),
+    }
+
+
+def _is_dup(words: list, word: dict, skip: int | None = None) -> bool:
+    for i, w in enumerate(words):
+        if i == skip:
+            continue
+        if (str(w.get("target", "")).strip().lower() == word["target"].strip().lower()
+                and w.get("language") == word["language"]):
+            return True
+    return False
+
+
+def add_word(raw: dict) -> dict:
+    with _lock:
+        _, words = _words_data()
+        word = _norm_word(raw)
+        if _is_dup(words, word):
+            raise ValueError(f"'{word['target']}' zaten kayıtlı.")
+        words.append(word)
+        rev = _bump_words(words)
+        return {"rev": rev, "count": len(words), "target": word["target"]}
+
+
+def edit_word(index: int, raw: dict) -> dict:
+    with _lock:
+        _, words = _words_data()
+        if not (0 <= index < len(words)):
+            raise ValueError("Geçersiz kelime seçimi.")
+        word = _norm_word(raw, existing=words[index])
+        if _is_dup(words, word, skip=index):
+            raise ValueError(f"'{word['target']}' zaten kayıtlı.")
+        words[index] = word
+        rev = _bump_words(words)
+        return {"rev": rev, "count": len(words), "target": word["target"]}
+
+
+def delete_word(index: int) -> dict:
+    with _lock:
+        _, words = _words_data()
+        if not (0 <= index < len(words)):
+            raise ValueError("Geçersiz kelime seçimi.")
+        target = words[index].get("target", "?")
+        del words[index]
+        rev = _bump_words(words)
+        return {"rev": rev, "count": len(words), "target": target}
+
+
+# --------------------------------------------------------------------------
+# Serverside .env (this device's own report/Telegram settings)
+# --------------------------------------------------------------------------
+
+def get_server_env() -> dict:
+    env = _parse_env_file(SERVER_ENV)
+    return {"env": env, "known": SERVER_ENV_KEYS}
+
+
+def save_server_env(mapping: dict) -> None:
+    if not isinstance(mapping, dict):
+        raise ValueError("env must be a JSON object")
+    clean = {}
+    for k, v in mapping.items():
+        key = str(k).strip()
+        if not _ENV_KEY_RE.match(key):
+            raise ValueError(f"Geçersiz anahtar adı: {k!r}")
+        clean[key] = str("" if v is None else v).replace("\n", " ").replace("\r", "")
+    lines = ["# Coalide parental stats server configuration",
+             "# Edited via the web admin. Restart the server to apply report changes.",
+             ""]
+    # Keep known keys first, in order, then any extras.
+    for key in SERVER_ENV_KEYS:
+        if key in clean:
+            lines.append(f"{key}={clean.pop(key)}")
+    for key, val in clean.items():
+        lines.append(f"{key}={val}")
+    tmp = SERVER_ENV + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+    os.replace(tmp, SERVER_ENV)

--- a/serverside/dashboard.html
+++ b/serverside/dashboard.html
@@ -1,0 +1,782 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Coalide — Veli Paneli</title>
+<style>
+  :root {
+    --bg: #0d0d18;
+    --surface: #16162a;
+    --surface2: #1c1c33;
+    --border: #2a2a45;
+    --grid: #23233c;
+    --purple: #7c5cff;
+    --green: #42d6a4;
+    --yellow: #f5c542;
+    --red: #ff6b81;
+    --blue: #5cc8ff;
+    --ink: #ececf6;
+    --ink2: #b8b8d4;
+    --muted: #8686a8;
+    --shadow: 0 1px 3px rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.28);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background:
+      radial-gradient(1200px 600px at 12% -10%, rgba(124,92,255,.10), transparent 60%),
+      radial-gradient(1000px 500px at 100% 0%, rgba(66,214,164,.07), transparent 55%),
+      var(--bg);
+    color: var(--ink);
+    font-family: "Segoe UI", system-ui, -apple-system, Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.45;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+  /* ---------- top bar ---------- */
+  header {
+    position: sticky; top: 0; z-index: 20;
+    background: rgba(13,13,24,.82);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border);
+    padding: 12px 24px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  .brand { display: flex; align-items: center; gap: 11px; }
+  .logo {
+    width: 34px; height: 34px; border-radius: 9px; flex: none;
+    background: linear-gradient(135deg, var(--purple), #b79bff);
+    display: grid; place-items: center; font-size: 18px;
+    box-shadow: 0 4px 14px rgba(124,92,255,.4);
+  }
+  .brand .t { font-size: 16px; font-weight: 700; letter-spacing: .2px; }
+  .brand .s { font-size: 11px; color: var(--muted); margin-top: -2px; }
+  .spacer { flex: 1; }
+  .ctl { display: flex; align-items: center; gap: 8px; }
+  .ctl label { font-size: 12px; color: var(--muted); }
+  select, button {
+    background: var(--surface); color: var(--ink);
+    border: 1px solid var(--border); border-radius: 9px;
+    padding: 8px 12px; font-size: 13px; font-family: inherit; cursor: pointer;
+    transition: border-color .15s, background .15s;
+  }
+  select:hover, button:hover { border-color: var(--purple); }
+  button:active { transform: translateY(1px); }
+  .updated { font-size: 12px; color: var(--muted); display: flex; align-items: center; gap: 6px; }
+  .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--green); box-shadow: 0 0 8px var(--green); }
+
+  /* ---------- layout ---------- */
+  main { max-width: 1240px; margin: 0 auto; padding: 22px 24px 56px; }
+  .tabs { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px; }
+  .tab {
+    padding: 8px 15px; border-radius: 999px; border: 1px solid var(--border);
+    background: var(--surface); color: var(--ink2); cursor: pointer; font-size: 13px;
+    font-weight: 600; transition: all .15s;
+  }
+  .tab:hover { border-color: var(--purple); color: var(--ink); }
+  .tab.active { color: #fff; background: linear-gradient(135deg, var(--purple), #9a7dff); border-color: transparent; box-shadow: 0 4px 14px rgba(124,92,255,.35); }
+  section.page { display: none; }
+  section.page.active { display: block; animation: fade .25s ease; }
+  @keyframes fade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+
+  .grid { display: grid; gap: 16px; grid-template-columns: repeat(12, 1fr); }
+  .col-12 { grid-column: span 12; } .col-8 { grid-column: span 8; }
+  .col-6 { grid-column: span 6; } .col-4 { grid-column: span 4; }
+  .col-3 { grid-column: span 3; }
+  @media (max-width: 900px) {
+    .col-8, .col-6, .col-4, .col-3 { grid-column: span 12; }
+  }
+
+  .card {
+    background: linear-gradient(180deg, var(--surface), var(--surface2));
+    border: 1px solid var(--border); border-radius: 16px;
+    padding: 18px 20px; box-shadow: var(--shadow);
+  }
+  .card > .h { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 4px; }
+  .card .title { font-size: 14px; font-weight: 700; }
+  .card .sub { font-size: 11.5px; color: var(--muted); }
+  .card .body { margin-top: 12px; }
+
+  /* KPI tiles */
+  .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 14px; }
+  .kpi { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 15px 16px; position: relative; overflow: hidden; }
+  .kpi::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--accent, var(--purple)); }
+  .kpi .l { font-size: 11.5px; color: var(--muted); font-weight: 600; margin-bottom: 7px; }
+  .kpi .v { font-size: 27px; font-weight: 800; letter-spacing: -.5px; }
+  .kpi .u { font-size: 12px; color: var(--muted); font-weight: 600; margin-left: 3px; }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 14px; font-size: 12px; color: var(--ink2); }
+  .legend .it { display: flex; align-items: center; gap: 6px; }
+  .legend .sw { width: 11px; height: 11px; border-radius: 3px; }
+  .legend .sw.line { width: 15px; height: 3px; border-radius: 2px; }
+
+  .kv { display: grid; grid-template-columns: auto 1fr; gap: 9px 16px; font-size: 13.5px; align-items: baseline; }
+  .kv .k { color: var(--muted); } .kv .v { font-weight: 600; text-align: right; }
+  .note { color: var(--muted); font-size: 12px; margin: 12px 0 0; }
+  .empty { color: var(--muted); font-style: italic; padding: 20px 0; text-align: center; }
+
+  /* hardest words */
+  .hrow { display: grid; grid-template-columns: 1fr 44px 90px; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--grid); }
+  .hrow:last-child { border-bottom: 0; }
+  .hrow .w { font-weight: 700; }
+  .hrow .track { grid-column: 1 / -1; height: 6px; background: var(--grid); border-radius: 4px; overflow: hidden; margin-top: -2px; }
+  .hrow .fill { height: 100%; border-radius: 4px; }
+  .hrow .pct { text-align: right; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .hrow .cnt { text-align: right; font-size: 12px; color: var(--ink2); }
+
+  /* progress ring center */
+  .ringwrap { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
+  .ringwrap .meta { flex: 1; min-width: 160px; }
+
+  /* table */
+  .table-wrap { max-height: 560px; overflow: auto; border-radius: 12px; border: 1px solid var(--border); }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { padding: 9px 12px; text-align: left; border-bottom: 1px solid var(--grid); white-space: nowrap; }
+  thead th { position: sticky; top: 0; background: var(--surface2); color: var(--muted); cursor: pointer; user-select: none; font-weight: 600; z-index: 1; }
+  thead th:hover { color: var(--ink); }
+  tbody tr:hover { background: rgba(124,92,255,.06); }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-weight: 700; font-size: 12px; }
+
+  /* meter (price tariff) */
+  .meter { margin: 9px 0; }
+  .meter .top { display: flex; justify-content: space-between; font-size: 12.5px; margin-bottom: 4px; }
+  .meter .top .now { color: var(--yellow); font-weight: 700; }
+  .meter .track { height: 9px; background: var(--grid); border-radius: 5px; overflow: hidden; }
+  .meter .fill { height: 100%; border-radius: 5px; background: linear-gradient(90deg, var(--green), var(--yellow) 60%, var(--red)); }
+
+  /* svg chart chrome */
+  svg.chart { width: 100%; height: auto; display: block; overflow: visible; }
+  .ax { fill: var(--muted); font-size: 10.5px; }
+  .gridline { stroke: var(--grid); stroke-width: 1; }
+  .hit { fill: transparent; cursor: crosshair; }
+  .crosshair { stroke: var(--muted); stroke-width: 1; stroke-dasharray: 3 3; pointer-events: none; opacity: 0; }
+
+  /* tooltip */
+  #tip {
+    position: fixed; z-index: 100; pointer-events: none; opacity: 0;
+    transform: translate(-50%, -114%); transition: opacity .1s;
+    background: rgba(20,20,36,.97); border: 1px solid var(--border);
+    border-radius: 10px; padding: 9px 11px; box-shadow: var(--shadow);
+    font-size: 12.5px; min-width: 120px; backdrop-filter: blur(4px);
+  }
+  #tip .tt { color: var(--muted); font-size: 11px; margin-bottom: 6px; }
+  #tip .tr { display: flex; align-items: center; gap: 8px; margin: 3px 0; }
+  #tip .tr .k { display: flex; align-items: center; gap: 6px; color: var(--ink2); }
+  #tip .tr .sw { width: 9px; height: 9px; border-radius: 2px; }
+  #tip .tr .sw.line { width: 13px; height: 3px; }
+  #tip .tr .val { margin-left: auto; font-weight: 800; font-variant-numeric: tabular-nums; }
+
+  #banner-msg { text-align: center; padding: 80px 20px; color: var(--muted); font-size: 15px; }
+</style>
+</head>
+<body data-palette="#42d6a4,#ff6b81,#f5c542,#7c5cff,#5cc8ff">
+<header>
+  <div class="brand">
+    <div class="logo">🌍</div>
+    <div><div class="t">COALIDE</div><div class="s">Veli Paneli</div></div>
+  </div>
+  <div class="spacer"></div>
+  <div class="ctl">
+    <label for="user">Öğrenci</label>
+    <select id="user"></select>
+  </div>
+  <button id="refresh">🔄 Yenile</button>
+  <a href="/admin" style="text-decoration:none"><button id="admin-btn">🛠️ Yönetim</button></a>
+  <div class="updated" id="updated"></div>
+</header>
+
+<main>
+  <div id="banner-msg">Yükleniyor…</div>
+  <div id="content" style="display:none">
+    <div class="tabs" id="tabs"></div>
+    <section class="page" data-page="genel"></section>
+    <section class="page" data-page="kredi"></section>
+    <section class="page" data-page="hafta"></section>
+    <section class="page" data-page="kelime"></section>
+    <section class="page" data-page="gelecek"></section>
+  </div>
+</main>
+<div id="tip"></div>
+
+<script>
+"use strict";
+const css = k => getComputedStyle(document.documentElement).getPropertyValue(k).trim();
+const C = {
+  purple: css('--purple'), green: css('--green'), yellow: css('--yellow'),
+  red: css('--red'), blue: css('--blue'), muted: css('--muted'),
+  ink: css('--ink'), ink2: css('--ink2'), grid: css('--grid'), surface: css('--surface'),
+};
+// Sequential single-hue ramp (light -> dark) for the ORDERED maturity buckets.
+const PURPLE_SEQ = ['#d9cfff','#baa4ff','#9a79ff','#7c5cff','#5f40c4','#43298c'];
+const MATURE = 21, CREDITS_PER_CORRECT = 7;
+const TR_MONTHS = ["Oca","Şub","Mar","Nis","May","Haz","Tem","Ağu","Eyl","Eki","Kas","Ara"];
+
+// ---------- DOM helpers ----------
+function el(tag, cls, html) { const e = document.createElement(tag); if (cls) e.className = cls; if (html != null) e.innerHTML = html; return e; }
+function txt(tag, cls, text) { const e = document.createElement(tag); if (cls) e.className = cls; if (text != null) e.textContent = text; return e; }
+const SVGNS = "http://www.w3.org/2000/svg";
+function s(tag, attrs) { const e = document.createElementNS(SVGNS, tag); for (const k in attrs) e.setAttribute(k, attrs[k]); return e; }
+function num(v) { return (v == null || isNaN(v)) ? 0 : +v; }
+function rateColor(r) { return r >= 80 ? C.green : r >= 50 ? C.yellow : C.red; }
+function fmtNum(v) { v = num(v); return Number.isInteger(v) ? v.toLocaleString("tr-TR") : v.toFixed(v < 1 ? 2 : 1); }
+function niceMax(m) { if (m <= 0) return 1; const p = Math.pow(10, Math.floor(Math.log10(m))); const n = m / p; const step = n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10; return step * p; }
+function dayLabel(d) { return `${d.getDate()} ${TR_MONTHS[d.getMonth()]}`; }
+function backLabels(todayStr, n) { const out = []; const t = new Date(todayStr + "T00:00:00"); for (let i = n - 1; i >= 0; i--) { const d = new Date(t); d.setDate(t.getDate() - i); out.push(dayLabel(d)); } return out; }
+
+// ---------- tooltip ----------
+const tip = document.getElementById("tip");
+function showTip(title, rows, x, y) {
+  tip.innerHTML = "";
+  tip.appendChild(txt("div", "tt", title));
+  for (const r of rows) {
+    const tr = el("div", "tr");
+    const k = el("div", "k");
+    const sw = el("span", "sw" + (r.line ? " line" : "")); sw.style.background = r.color;
+    k.appendChild(sw); k.appendChild(txt("span", null, r.name));
+    tr.appendChild(k);
+    tr.appendChild(txt("span", "val", r.value));
+    tip.appendChild(tr);
+  }
+  tip.style.left = x + "px"; tip.style.top = y + "px"; tip.style.opacity = 1;
+}
+function hideTip() { tip.style.opacity = 0; }
+
+// ---------- cards ----------
+function card(title, sub, cls) {
+  const c = el("div", "card " + (cls || ""));
+  const h = el("div", "h");
+  h.appendChild(txt("div", "title", title));
+  if (sub) h.appendChild(txt("div", "sub", sub));
+  c.appendChild(h);
+  const b = el("div", "body"); c.appendChild(b);
+  c._body = b; return c;
+}
+function legendBar(items) {
+  const l = el("div", "legend");
+  for (const [color, name, isLine] of items) {
+    const it = el("div", "it");
+    const sw = el("span", "sw" + (isLine ? " line" : "")); sw.style.background = color;
+    it.appendChild(sw); it.appendChild(txt("span", null, name));
+    l.appendChild(it);
+  }
+  return l;
+}
+
+// =====================================================================
+//  CHART PRIMITIVES (inline SVG, no dependencies)
+// =====================================================================
+const W = 720; // viewBox width; height varies per chart. Scales via width:100%.
+
+// Line / area chart with crosshair + all-series tooltip.
+function lineChart(opts) {
+  const { labels, series, height = 230, area = false, valueFmt = fmtNum } = opts;
+  const H = height, padL = 44, padR = 14, padT = 14, padB = 26;
+  const plotW = W - padL - padR, plotH = H - padT - padB;
+  const n = labels.length;
+  const allVals = series.flatMap(se => se.values.map(num));
+  const ymax = niceMax(Math.max(1, ...allVals));
+  const X = i => padL + (n <= 1 ? plotW / 2 : (i / (n - 1)) * plotW);
+  const Y = v => padT + plotH - (num(v) / ymax) * plotH;
+  const svg = s("svg", { class: "chart", viewBox: `0 0 ${W} ${H}`, preserveAspectRatio: "none" });
+
+  // y gridlines + ticks
+  const ticks = 4;
+  for (let t = 0; t <= ticks; t++) {
+    const v = ymax * t / ticks, y = Y(v);
+    svg.appendChild(s("line", { class: "gridline", x1: padL, y1: y, x2: W - padR, y2: y }));
+    const lbl = s("text", { class: "ax", x: padL - 8, y: y + 3, "text-anchor": "end" });
+    lbl.textContent = valueFmt(Math.round(v)); svg.appendChild(lbl);
+  }
+  // x labels (thin to ~6)
+  const step = Math.max(1, Math.ceil(n / 6));
+  for (let i = 0; i < n; i += step) {
+    const tx = s("text", { class: "ax", x: X(i), y: H - 8, "text-anchor": "middle" });
+    tx.textContent = labels[i]; svg.appendChild(tx);
+  }
+  // series
+  for (const se of series) {
+    const pts = se.values.map((v, i) => [X(i), Y(v)]);
+    const d = pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" ");
+    if (area && series.length === 1) {
+      const ad = d + ` L ${X(n - 1).toFixed(1)} ${Y(0)} L ${X(0).toFixed(1)} ${Y(0)} Z`;
+      const fill = s("path", { d: ad, fill: se.color, "fill-opacity": .12, stroke: "none" });
+      svg.appendChild(fill);
+    }
+    svg.appendChild(s("path", { d, fill: "none", stroke: se.color, "stroke-width": 2, "stroke-linejoin": "round", "stroke-linecap": "round" }));
+    // end dot with surface ring
+    const lx = X(n - 1), ly = Y(se.values[n - 1]);
+    svg.appendChild(s("circle", { cx: lx, cy: ly, r: 4, fill: se.color, stroke: C.surface, "stroke-width": 2 }));
+  }
+  // crosshair + hover
+  const cross = s("line", { class: "crosshair", y1: padT, y2: padT + plotH });
+  svg.appendChild(cross);
+  const dots = series.map(se => { const c = s("circle", { r: 4, fill: se.color, stroke: C.surface, "stroke-width": 2, opacity: 0 }); svg.appendChild(c); return c; });
+  const hit = s("rect", { class: "hit", x: padL, y: padT, width: plotW, height: plotH });
+  svg.appendChild(hit);
+  const pxToView = (clientX, rect) => (clientX - rect.left) / rect.width * W;
+  hit.addEventListener("pointermove", ev => {
+    const rect = svg.getBoundingClientRect();
+    const vx = pxToView(ev.clientX, rect);
+    let i = Math.round((vx - padL) / plotW * (n - 1)); i = Math.max(0, Math.min(n - 1, i));
+    cross.setAttribute("x1", X(i)); cross.setAttribute("x2", X(i)); cross.setAttribute("opacity", 1);
+    dots.forEach((dot, k) => { dot.setAttribute("cx", X(i)); dot.setAttribute("cy", Y(series[k].values[i])); dot.setAttribute("opacity", 1); });
+    showTip(labels[i], series.map(se => ({ color: se.color, name: se.name, value: valueFmt(num(se.values[i])), line: true })), ev.clientX, rect.top + Y(Math.max(...series.map(se => num(se.values[i])))));
+  });
+  hit.addEventListener("pointerleave", () => { cross.setAttribute("opacity", 0); dots.forEach(d => d.setAttribute("opacity", 0)); hideTip(); });
+  return svg;
+}
+
+// Column chart — single or grouped series. rows-agnostic; per-series values.
+function columnChart(opts) {
+  const { labels, series, height = 230, valueFmt = fmtNum, colorsPerBar = null } = opts;
+  const H = height, padL = 44, padR = 14, padT = 14, padB = 28;
+  const plotW = W - padL - padR, plotH = H - padT - padB;
+  const n = labels.length, g = series.length;
+  const allVals = series.flatMap(se => se.values.map(num));
+  const ymax = niceMax(Math.max(1, ...allVals));
+  const Y = v => padT + plotH - (num(v) / ymax) * plotH;
+  const band = plotW / n;
+  const innerPad = Math.min(band * 0.25, 10);
+  const groupW = band - innerPad;
+  const barW = Math.min(groupW / g, 24);
+  const gap = 2; // surface gap between adjacent bars
+  const svg = s("svg", { class: "chart", viewBox: `0 0 ${W} ${H}`, preserveAspectRatio: "none" });
+  const ticks = 4;
+  for (let t = 0; t <= ticks; t++) {
+    const v = ymax * t / ticks, y = Y(v);
+    svg.appendChild(s("line", { class: "gridline", x1: padL, y1: y, x2: W - padR, y2: y }));
+    const lbl = s("text", { class: "ax", x: padL - 8, y: y + 3, "text-anchor": "end" }); lbl.textContent = valueFmt(Math.round(v)); svg.appendChild(lbl);
+  }
+  const step = Math.max(1, Math.ceil(n / 8));
+  for (let i = 0; i < n; i++) {
+    const cx = padL + band * i + band / 2;
+    if (i % step === 0) { const tx = s("text", { class: "ax", x: cx, y: H - 9, "text-anchor": "middle" }); tx.textContent = labels[i]; svg.appendChild(tx); }
+    const groupStart = cx - (barW * g + gap * (g - 1)) / 2;
+    series.forEach((se, k) => {
+      const v = num(se.values[i]); if (v <= 0 && g > 1) { /* still draw hit? skip zero */ }
+      const h = Math.max(0, (v / ymax) * plotH);
+      const x = groupStart + k * (barW + gap);
+      const y = Y(v);
+      const color = colorsPerBar ? colorsPerBar[i] : se.color;
+      const r = Math.min(4, barW / 2, h);
+      // rounded top, square baseline
+      const path = h > 0
+        ? `M${x} ${y + r} a${r} ${r} 0 0 1 ${r} ${-r} h${barW - 2 * r} a${r} ${r} 0 0 1 ${r} ${r} v${h - r} h${-barW} Z`
+        : "";
+      if (h > 0) {
+        const bar = s("path", { d: path, fill: color });
+        bar.style.transition = "opacity .12s";
+        bar.addEventListener("pointerenter", ev => { bar.setAttribute("opacity", .8); const rect = svg.getBoundingClientRect(); showTip(labels[i], series.map(ss => ({ color: colorsPerBar ? colorsPerBar[i] : ss.color, name: ss.name, value: valueFmt(num(ss.values[i])) })), ev.clientX, rect.top + rect.height * (y / H)); });
+        bar.addEventListener("pointerleave", () => { bar.setAttribute("opacity", 1); hideTip(); });
+        svg.appendChild(bar);
+      }
+    });
+  }
+  return svg;
+}
+
+// Stacked-100% horizontal distribution bar with sequential ramp (ordered cats).
+function stackedDistribution(rows) {
+  // rows: [{label, value, color}]
+  const total = rows.reduce((a, r) => a + num(r.value), 0) || 1;
+  const wrap = el("div");
+  const barH = 26;
+  const bar = el("div"); bar.style.cssText = `display:flex; height:${barH}px; border-radius:8px; overflow:hidden; background:var(--grid); gap:2px;`;
+  rows.forEach(r => {
+    if (num(r.value) <= 0) return;
+    const seg = el("div");
+    seg.style.cssText = `width:${num(r.value) / total * 100}%; background:${r.color};`;
+    seg.addEventListener("pointerenter", ev => showTip(r.label, [{ color: r.color, name: "Kelime", value: fmtNum(r.value) + `  (%${(num(r.value) / total * 100).toFixed(0)})` }], ev.clientX, ev.clientY));
+    seg.addEventListener("pointermove", ev => { tip.style.left = ev.clientX + "px"; tip.style.top = ev.clientY + "px"; });
+    seg.addEventListener("pointerleave", hideTip);
+    bar.appendChild(seg);
+  });
+  wrap.appendChild(bar);
+  // legend grid with counts
+  const leg = el("div"); leg.style.cssText = "display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:8px 16px; margin-top:14px;";
+  rows.forEach(r => {
+    const it = el("div"); it.style.cssText = "display:flex; align-items:center; gap:8px; font-size:12.5px;";
+    const sw = el("span"); sw.style.cssText = `width:11px;height:11px;border-radius:3px;background:${r.color};flex:none;`;
+    it.appendChild(sw);
+    it.appendChild(txt("span", null, r.label));
+    const v = txt("span", null, fmtNum(r.value)); v.style.cssText = "margin-left:auto; font-weight:700; color:var(--ink2);";
+    it.appendChild(v);
+    leg.appendChild(it);
+  });
+  wrap.appendChild(leg);
+  return wrap;
+}
+
+// Donut with hover + center total.
+function donut(opts) {
+  const { segments, centerValue, centerLabel, size = 190 } = opts;
+  const total = segments.reduce((a, x) => a + num(x.value), 0);
+  const r = size / 2, cx = r, cy = r, thick = size * 0.19, rr = r - thick / 2;
+  const svg = s("svg", { class: "chart", viewBox: `0 0 ${size} ${size}`, width: size, height: size, style: "width:" + size + "px; max-width:100%;" });
+  if (total <= 0) {
+    svg.appendChild(s("circle", { cx, cy, r: rr, fill: "none", stroke: C.grid, "stroke-width": thick }));
+  } else {
+    let a0 = -Math.PI / 2;
+    const gap = 0.03; // radians surface gap
+    segments.forEach(seg => {
+      const v = num(seg.value); if (v <= 0) return;
+      const frac = v / total; const a1 = a0 + frac * Math.PI * 2;
+      const s0 = a0 + gap / 2, s1 = a1 - gap / 2;
+      const large = (s1 - s0) > Math.PI ? 1 : 0;
+      const x0 = cx + rr * Math.cos(s0), y0 = cy + rr * Math.sin(s0);
+      const x1 = cx + rr * Math.cos(s1), y1 = cy + rr * Math.sin(s1);
+      const path = s("path", { d: `M${x0} ${y0} A${rr} ${rr} 0 ${large} 1 ${x1} ${y1}`, fill: "none", stroke: seg.color, "stroke-width": thick, "stroke-linecap": "butt" });
+      path.style.transition = "stroke-width .12s";
+      path.addEventListener("pointerenter", ev => { path.setAttribute("stroke-width", thick + 5); showTip(seg.name, [{ color: seg.color, name: "Adet", value: fmtNum(v) + `  (%${(frac * 100).toFixed(0)})` }], ev.clientX, ev.clientY); });
+      path.addEventListener("pointermove", ev => { tip.style.left = ev.clientX + "px"; tip.style.top = ev.clientY + "px"; });
+      path.addEventListener("pointerleave", () => { path.setAttribute("stroke-width", thick); hideTip(); });
+      svg.appendChild(path);
+      a0 = a1;
+    });
+  }
+  const t1 = s("text", { x: cx, y: cy - 2, "text-anchor": "middle", fill: C.ink, "font-size": size * 0.2, "font-weight": 800 }); t1.textContent = centerValue;
+  const t2 = s("text", { x: cx, y: cy + size * 0.13, "text-anchor": "middle", fill: C.muted, "font-size": size * 0.075 }); t2.textContent = centerLabel;
+  svg.appendChild(t1); svg.appendChild(t2);
+  return svg;
+}
+
+// Progress ring (single value, status color).
+function progressRing(opts) {
+  const { value, max = 100, color, label, size = 180, unit = "%" } = opts;
+  const r = size / 2, cx = r, cy = r, thick = size * 0.11, rr = r - thick / 2;
+  const frac = Math.max(0, Math.min(1, num(value) / max));
+  const circ = 2 * Math.PI * rr;
+  const svg = s("svg", { class: "chart", viewBox: `0 0 ${size} ${size}`, width: size, height: size, style: "width:" + size + "px;" });
+  svg.appendChild(s("circle", { cx, cy, r: rr, fill: "none", stroke: C.grid, "stroke-width": thick }));
+  svg.appendChild(s("circle", { cx, cy, r: rr, fill: "none", stroke: color, "stroke-width": thick, "stroke-linecap": "round", "stroke-dasharray": `${circ * frac} ${circ}`, transform: `rotate(-90 ${cx} ${cy})` }));
+  const t1 = s("text", { x: cx, y: cy + size * 0.02, "text-anchor": "middle", fill: C.ink, "font-size": size * 0.26, "font-weight": 800 }); t1.textContent = Math.round(num(value)) + unit;
+  const t2 = s("text", { x: cx, y: cy + size * 0.19, "text-anchor": "middle", fill: C.muted, "font-size": size * 0.08 }); t2.textContent = label;
+  svg.appendChild(t1); svg.appendChild(t2);
+  return svg;
+}
+
+// KPI tiles
+function kpiRow(items) {
+  const g = el("div", "kpis");
+  for (const it of items) {
+    const k = el("div", "kpi"); k.style.setProperty("--accent", it.color || C.purple);
+    k.appendChild(txt("div", "l", it.label));
+    const v = el("div", "v"); v.appendChild(txt("span", null, fmtNum(it.value)));
+    if (it.unit) v.appendChild(txt("span", "u", it.unit));
+    k.appendChild(v);
+    g.appendChild(k);
+  }
+  return g;
+}
+
+// =====================================================================
+//  PAGES
+// =====================================================================
+function gcol(span, node) { const d = el("div", "col-" + span); d.appendChild(node); return d; }
+
+function pageGenel(st) {
+  const root = el("div", "grid");
+
+  // Hero: success ring + KPIs
+  const heroCard = card("Genel Başarı", "tüm kayıtlı cevaplara göre");
+  const ring = el("div", "ringwrap");
+  ring.appendChild(progressRing({ value: num(st.overall_rate), color: rateColor(num(st.overall_rate)), label: "başarı oranı" }));
+  const meta = el("div", "meta");
+  const lt = st.log_totals || {};
+  meta.appendChild(kpiRow([
+    { label: "Doğru", value: num(lt.correct), unit: "", color: C.green },
+    { label: "Yanlış", value: num(lt.wrong), color: C.red },
+    { label: "Boş", value: num(lt.blank), color: C.yellow },
+    { label: "Seri", value: num(st.streak), unit: "gün", color: C.purple },
+  ]));
+  ring.appendChild(meta);
+  heroCard._body.appendChild(ring);
+  root.appendChild(gcol(5, heroCard));
+
+  // KPI overview
+  const kpiCard = card("Özet", "");
+  kpiCard._body.appendChild(kpiRow([
+    { label: "Toplam kelime", value: st.total_words, color: C.purple },
+    { label: "Başlanan", value: st.started_count, color: C.green },
+    { label: `Öğrenilen (${MATURE}g+)`, value: st.mastered, color: C.yellow },
+    { label: "Bugün yeni", value: st.new_today, color: C.green },
+    { label: "Tekrar bekleyen", value: st.due_now, color: C.red },
+    { label: "Kredi", value: st.balance, color: C.yellow },
+  ]));
+  root.appendChild(gcol(7, kpiCard));
+
+  // Maturity distribution (ordered -> sequential ramp)
+  const buckets = (st.buckets || []).map((b, i) => ({ label: b[0], value: b[1], color: PURPLE_SEQ[i] || C.purple }));
+  const matCard = card("Kelime Olgunluğu", "SM-2 aralığına göre dağılım");
+  matCard._body.appendChild(stackedDistribution(buckets));
+  root.appendChild(gcol(8, matCard));
+
+  // All-time donut
+  const dCard = card("Cevap Dağılımı", "tüm zamanlar");
+  if (num(st.log_total) > 0) {
+    const dwrap = el("div"); dwrap.style.cssText = "display:flex; flex-direction:column; align-items:center; gap:12px;";
+    dwrap.appendChild(donut({ segments: [
+      { name: "Doğru", value: num(lt.correct), color: C.green },
+      { name: "Yanlış", value: num(lt.wrong), color: C.red },
+      { name: "Boş", value: num(lt.blank), color: C.yellow },
+    ], centerValue: fmtNum(st.log_total), centerLabel: "cevap" }));
+    dwrap.appendChild(legendBar([[C.green, "Doğru"], [C.red, "Yanlış"], [C.yellow, "Boş"]]));
+    dCard._body.appendChild(dwrap);
+  } else { dCard._body.appendChild(el("div", "empty", "Henüz cevap kaydı yok.")); }
+  root.appendChild(gcol(4, dCard));
+
+  // Activity 30d line
+  const actCard = card("Aktivite", "günlük cevap sayısı · son 30 gün");
+  actCard._body.appendChild(lineChart({ labels: backLabels(st.today, (st.spark_30 || []).length), series: [{ name: "Cevap", color: C.green, values: st.spark_30 || [] }], area: true }));
+  root.appendChild(gcol(8, actCard));
+
+  // Hardest words
+  const hCard = card("En Zor Kelimeler", "en düşük başarı");
+  if (st.hardest && st.hardest.length) {
+    for (const e of st.hardest) {
+      const rc = rateColor(num(e.rate));
+      const row = el("div", "hrow");
+      row.appendChild(txt("div", "w", e.word));
+      row.appendChild(txt("div", "pct", "%" + Math.round(num(e.rate)))).style.color = rc;
+      row.appendChild(txt("div", "cnt", `${e.correct}✓ ${e.wrong}✗ ${e.blank}∅`));
+      const track = el("div", "track"); const fill = el("div", "fill");
+      fill.style.width = Math.max(3, num(e.rate)) + "%"; fill.style.background = rc; track.appendChild(fill);
+      row.appendChild(track);
+      hCard._body.appendChild(row);
+    }
+  } else { hCard._body.appendChild(el("div", "empty", "Henüz veri yok.")); }
+  root.appendChild(gcol(4, hCard));
+
+  return root;
+}
+
+function pageKredi(st) {
+  const root = el("div", "grid");
+  const kCard = card("Kredi Özeti", "");
+  kCard._body.appendChild(kpiRow([
+    { label: "Bakiye", value: st.balance, color: C.yellow },
+    { label: "Alınabilir bugün", value: st.max_today, unit: "dk", color: C.green },
+    { label: "Bugün alınan", value: st.redeemed_today, unit: "dk", color: C.purple },
+    { label: "Bu hafta kazanılan", value: st.earned_week, color: C.green },
+    { label: "Bu hafta harcanan", value: st.spent_week, color: C.red },
+    { label: "Sıfırlamaya", value: st.days_to_reset == null ? 0 : st.days_to_reset, unit: "gün", color: C.red },
+  ]));
+  root.appendChild(gcol(12, kCard));
+
+  // Earned vs spent grouped columns (14d)
+  const earned = st.earned_14 || [], spent = st.spent_14 || [];
+  const labels = earned.map(r => r[0]);
+  const esCard = card("Kazanılan vs Harcanan Kredi", "son 14 gün");
+  esCard._body.appendChild(legendBar([[C.green, "Kazanılan"], [C.red, "Harcanan"]]));
+  const esWrap = el("div"); esWrap.style.marginTop = "10px";
+  esWrap.appendChild(columnChart({ labels, series: [
+    { name: "Kazanılan", color: C.green, values: earned.map(r => r[1]) },
+    { name: "Harcanan", color: C.red, values: spent.map(r => r[1]) },
+  ] }));
+  esCard._body.appendChild(esWrap);
+  esCard._body.appendChild(txt("p", "note", `Toplam kazanç ${fmtNum(st.earned_total)} · toplam harcama ${fmtNum(st.spent_total)} kredi (son 60 gün). Her doğru cevap = ${CREDITS_PER_CORRECT} kredi.`));
+  root.appendChild(gcol(7, esCard));
+
+  // Screen time 30d area
+  const stCard = card("Ekran Süresi", "dk/gün · son 30 gün");
+  stCard._body.appendChild(lineChart({ labels: backLabels(st.today, (st.spark_minutes_30 || []).length), series: [{ name: "Dakika", color: C.yellow, values: st.spark_minutes_30 || [] }], area: true, valueFmt: v => v }));
+  root.appendChild(gcol(5, stCard));
+
+  // Redeemed weekly columns
+  const rw = st.redeemed_weekly || [];
+  const rwCard = card("Haftalık Ekran Süresi", "son 8 hafta · dakika");
+  rwCard._body.appendChild(columnChart({ labels: rw.map(r => r[0]), series: [{ name: "Dakika", color: C.blue, values: rw.map(r => r[1]) }], valueFmt: v => v }));
+  root.appendChild(gcol(7, rwCard));
+
+  // Price tariff meter
+  const tCard = card("Fiyat Tarifesi", "her ek saat dakikayı pahalılaştırır");
+  const nowHour = Math.floor(num(st.redeemed_today) / 60);
+  const brackets = st.price_brackets || [];
+  const maxRate = Math.max(1, ...brackets.map(b => num(b[1])));
+  brackets.forEach(([h, rate]) => {
+    const m = el("div", "meter");
+    const top = el("div", "top");
+    top.appendChild(txt("span", null, `${h + 1}. saat`));
+    const rt = el("span", (h === nowHour) ? "now" : null, fmtNum(rate) + " kredi/dk" + (h === nowHour ? "  ◀ şu an" : ""));
+    top.appendChild(rt);
+    m.appendChild(top);
+    const track = el("div", "track"); const fill = el("div", "fill");
+    fill.style.width = (num(rate) / maxRate * 100) + "%"; track.appendChild(fill); m.appendChild(track);
+    tCard._body.appendChild(m);
+  });
+  tCard._body.appendChild(txt("p", "note", `Bakiyeyle alınabilir: ${fmtNum(st.max_today)} dk (bugün) · ${fmtNum(st.max_tomorrow)} dk (yarın).`));
+  root.appendChild(gcol(5, tCard));
+
+  return root;
+}
+
+function pageHafta(st) {
+  const root = el("div", "grid");
+  // Daily answers grouped columns (14d)
+  const da = st.daily_answers || [];
+  const daCard = card("Günlük Cevaplar", "son 14 gün");
+  daCard._body.appendChild(legendBar([[C.green, "Doğru"], [C.red, "Yanlış"], [C.yellow, "Boş"]]));
+  const daWrap = el("div"); daWrap.style.marginTop = "10px";
+  daWrap.appendChild(columnChart({ labels: da.map(r => r[0]), series: [
+    { name: "Doğru", color: C.green, values: da.map(r => (r[1][0] || [0])[0]) },
+    { name: "Yanlış", color: C.red, values: da.map(r => (r[1][1] || [0])[0]) },
+    { name: "Boş", color: C.yellow, values: da.map(r => (r[1][2] || [0])[0]) },
+  ] }));
+  daCard._body.appendChild(daWrap);
+  root.appendChild(gcol(12, daCard));
+
+  // Weekly new columns
+  const wn = st.weekly_new || [];
+  const wnCard = card("Haftalık Yeni Kelimeler", "son 8 hafta");
+  wnCard._body.appendChild(columnChart({ labels: wn.map(r => r[0]), series: [{ name: "Yeni kelime", color: C.green, values: wn.map(r => r[1]) }] }));
+  root.appendChild(gcol(6, wnCard));
+
+  // Daily new columns
+  const dn = st.daily_new || [];
+  const dnCard = card("Günlük Yeni Kelimeler", "son 14 gün");
+  dnCard._body.appendChild(columnChart({ labels: dn.map(r => r[0]), series: [{ name: "Yeni kelime", color: C.purple, values: dn.map(r => r[1]) }] }));
+  root.appendChild(gcol(6, dnCard));
+
+  // New words 30d line
+  const nwCard = card("Yeni Kelime Trendi", "son 30 gün");
+  nwCard._body.appendChild(lineChart({ labels: backLabels(st.today, (st.spark_new_30 || []).length), series: [{ name: "Yeni kelime", color: C.purple, values: st.spark_new_30 || [] }], area: true }));
+  root.appendChild(gcol(12, nwCard));
+
+  return root;
+}
+
+let _tableSort = { col: "rate", dir: 1 };
+function pageKelime(st) {
+  const root = el("div", "grid");
+  // Word types bars
+  const types = Object.entries(st.word_types || {}).sort((a, b) => b[1] - a[1]);
+  const tCard = card("Kelime Türleri", "");
+  tCard._body.appendChild(columnChart({ labels: types.map(t => t[0]), series: [{ name: "Adet", color: C.blue, values: types.map(t => t[1]) }], height: 200 }));
+  root.appendChild(gcol(12, tCard));
+
+  // Table
+  const wCard = card("Tüm Kelimeler", `${st.started_count} başlanan · en zordan kolaya`);
+  const cols = [["word", "Kelime", 0], ["rate", "Başarı", 1], ["correct", "✓", 1], ["wrong", "✗", 1], ["blank", "∅", 1], ["repetitions", "Tekrar", 1], ["interval", "Aralık", 1], ["next", "Sonraki tekrar", 0]];
+  const wrap = el("div", "table-wrap");
+  const table = el("table"); const thead = el("thead"); const htr = el("tr");
+  cols.forEach(([key, label, isNum]) => {
+    const th = txt("th", isNum ? "num" : null, label);
+    th.onclick = () => { _tableSort.dir = (_tableSort.col === key) ? -_tableSort.dir : 1; _tableSort.col = key; render(); };
+    htr.appendChild(th);
+  });
+  thead.appendChild(htr); table.appendChild(thead);
+  const tbody = el("tbody"); table.appendChild(tbody); wrap.appendChild(table);
+  wCard._body.appendChild(wrap); root.appendChild(gcol(12, wCard));
+
+  const rows = (st.table_rows || []).slice(); const today = st.today;
+  function render() {
+    const k = _tableSort.col, d = _tableSort.dir;
+    rows.sort((a, b) => { let x = a[k], y = b[k]; if (typeof x === "string" || typeof y === "string") return String(x || "").localeCompare(String(y || "")) * d; return (num(x) - num(y)) * d; });
+    tbody.innerHTML = "";
+    for (const e of rows) {
+      const tr = el("tr"); const rc = rateColor(num(e.rate));
+      tr.appendChild(txt("td", null, e.word)).style.fontWeight = 700;
+      const rateTd = el("td", "num");
+      if (e.total) { const p = txt("span", "pill", "%" + Math.round(num(e.rate))); p.style.color = rc; p.style.background = "rgba(255,255,255,.05)"; rateTd.appendChild(p); } else rateTd.textContent = "—";
+      tr.appendChild(rateTd);
+      tr.appendChild(txt("td", "num", num(e.correct))).style.color = C.green;
+      tr.appendChild(txt("td", "num", num(e.wrong))).style.color = C.red;
+      tr.appendChild(txt("td", "num", num(e.blank))).style.color = C.yellow;
+      tr.appendChild(txt("td", "num", num(e.repetitions)));
+      tr.appendChild(txt("td", "num", num(e.interval) + "g"));
+      const nx = el("td");
+      if (e.next) { const delta = Math.round((new Date(e.next) - new Date(today)) / 86400000); const c = txt("span", null, `${e.next} (${delta >= 0 ? "+" : ""}${delta}g)`); c.style.color = delta <= 0 ? C.red : C.muted; nx.appendChild(c); } else nx.textContent = "—";
+      tr.appendChild(nx);
+      tbody.appendChild(tr);
+    }
+  }
+  render();
+  return root;
+}
+
+function pageGelecek(st) {
+  const root = el("div", "grid");
+  const fc = st.forecast || [];
+  const fCard = card("Tekrar Takvimi", "gelecek 14 gün");
+  const colors = fc.map((r, i) => i === 0 ? C.red : (i === 1 ? C.yellow : C.purple));
+  fCard._body.appendChild(columnChart({ labels: fc.map(r => r[0]), series: [{ name: "Kelime", color: C.purple, values: fc.map(r => r[1]) }], colorsPerBar: colors }));
+  root.appendChild(gcol(8, fCard));
+
+  const sCard = card("SM-2 Sağlığı", "aralık algoritması");
+  const eases = st.eases || [], intervals = st.intervals || [];
+  if (eases.length) {
+    const avg = a => a.reduce((x, y) => x + y, 0) / a.length;
+    const kv = el("div", "kv");
+    const add = (k, v) => { kv.appendChild(txt("div", "k", k)); const d = el("div", "v"); d.innerHTML = v; kv.appendChild(d); };
+    add("Ortalama kolaylık (EF)", `${avg(eases).toFixed(2)}`);
+    add("En düşük / yüksek EF", `${Math.min(...eases).toFixed(2)} / ${Math.max(...eases).toFixed(2)}`);
+    add("Ortalama aralık", `${Math.round(avg(intervals))} gün`);
+    if (st.longest) { kv.appendChild(txt("div", "k", "En uzun aralık")); const d = el("div", "v"); d.appendChild(txt("span", null, st.longest.word + " ")); const g = txt("span", null, `(${st.longest.interval} gün)`); g.style.color = C.green; d.appendChild(g); kv.appendChild(d); }
+    sCard._body.appendChild(kv);
+    sCard._body.appendChild(txt("p", "note", "EF: 1.30 en zor, 2.50 varsayılan."));
+  } else { sCard._body.appendChild(el("div", "empty", "Henüz çalışılmış kelime yok.")); }
+  root.appendChild(gcol(4, sCard));
+
+  return root;
+}
+
+const PAGES = {
+  genel: ["📊 Genel Bakış", pageGenel],
+  kredi: ["💰 Krediler", pageKredi],
+  hafta: ["📅 Haftalık & Günlük", pageHafta],
+  kelime: ["🔤 Kelimeler", pageKelime],
+  gelecek: ["🔮 Gelecek & SM-2", pageGelecek],
+};
+let _active = "genel";
+function buildTabs() {
+  const t = document.getElementById("tabs"); t.innerHTML = "";
+  Object.entries(PAGES).forEach(([key, [label]]) => {
+    const b = txt("div", "tab" + (key === _active ? " active" : ""), label);
+    b.onclick = () => { _active = key; showPage(); };
+    t.appendChild(b);
+  });
+}
+function showPage() {
+  const keys = Object.keys(PAGES);
+  document.querySelectorAll(".tab").forEach((t, i) => t.classList.toggle("active", keys[i] === _active));
+  document.querySelectorAll("section.page").forEach(sec => sec.classList.toggle("active", sec.dataset.page === _active));
+}
+function renderAll(stats) {
+  Object.entries(PAGES).forEach(([key, [, builder]]) => {
+    const sec = document.querySelector(`section.page[data-page="${key}"]`);
+    sec.innerHTML = "";
+    try { sec.appendChild(builder(stats)); }
+    catch (err) { sec.appendChild(el("div", "empty", "Bu sekme çizilemedi: " + err.message)); console.error(err); }
+  });
+  buildTabs(); showPage();
+}
+
+// ---------- data ----------
+async function loadUsers() { const r = await fetch("/api/users"); return (await r.json()).users || []; }
+async function loadStats(u) { const r = await fetch("/api/stats" + (u ? "?user=" + encodeURIComponent(u) : "")); if (!r.ok) throw new Error((await r.json()).error || r.statusText); return r.json(); }
+function timeAgo(iso) { if (!iso) return ""; const secs = Math.round((Date.now() - new Date(iso).getTime()) / 1000); if (secs < 60) return "az önce"; if (secs < 3600) return Math.floor(secs / 60) + " dk önce"; if (secs < 86400) return Math.floor(secs / 3600) + " saat önce"; return new Date(iso).toLocaleString("tr-TR"); }
+
+async function refresh() {
+  const banner = document.getElementById("banner-msg"), content = document.getElementById("content"), sel = document.getElementById("user");
+  try {
+    const users = await loadUsers();
+    if (!users.length) { content.style.display = "none"; banner.style.display = "block"; banner.textContent = "Henüz veri yok. Çocuğun uygulaması menüyü açtığında istatistikler burada görünecek."; return; }
+    const prev = sel.value; sel.innerHTML = "";
+    users.forEach(u => { const o = txt("option", null, u.username); o.value = u.username; sel.appendChild(o); });
+    if (prev && users.some(u => u.username === prev)) sel.value = prev;
+    const rec = await loadStats(sel.value);
+    const up = document.getElementById("updated"); up.innerHTML = ""; up.appendChild(el("span", "dot")); up.appendChild(txt("span", null, "Güncellendi: " + timeAgo(rec.updated_at)));
+    banner.style.display = "none"; content.style.display = "block";
+    renderAll(rec.stats || {});
+  } catch (err) { content.style.display = "none"; banner.style.display = "block"; banner.textContent = "Yüklenemedi: " + err.message; }
+}
+document.getElementById("refresh").onclick = refresh;
+document.getElementById("user").onchange = refresh;
+refresh();
+setInterval(refresh, 30000);
+</script>
+</body>
+</html>

--- a/serverside/report.py
+++ b/serverside/report.py
@@ -58,7 +58,8 @@ def _parse_env_file(path: str) -> dict:
 def _looks_like_placeholder(v: str) -> bool:
     if not v:
         return True
-    bad = ("ENTER_YOUR_TOKEN", "YOUR_CHAT_ID", "IP-TO-YOUR", "YOUR-PARENT-SERVER")
+    bad = ("ENTER_YOUR_TOKEN", "YOUR_CHAT_ID", "YOUR_BOT_TOKEN", "YOUR-BOT-TOKEN",
+           "IP-TO-YOUR", "YOUR-PARENT-SERVER")
     return v.startswith("[") or any(b in v for b in bad)
 
 

--- a/serverside/report.py
+++ b/serverside/report.py
@@ -1,0 +1,273 @@
+"""
+Coalide — daily Telegram report (server side).
+
+Builds a text summary of every learner's stored stats and sends it to the
+parent over Telegram, once a day at a configured time (midnight by default).
+The dashboard URL is appended at the end so the parent can open the full view.
+
+Zero dependencies — uses only the standard library (urllib for the Telegram
+Bot API), so it ships inside `serverside/` without touching the main app's
+requirements.
+
+Configuration (environment variables, or a `.env` file next to server.py /
+in its parent folder). Both the Telegram-style and Coalide-style names work:
+
+    TELEGRAM_BOT_TOKEN / BOT_TOKEN     Telegram bot token
+    TELEGRAM_CHAT_ID   / CHAT_ID       Chat/channel id to send to
+    COALIDE_DASHBOARD_URL              Public dashboard URL (for the footer link)
+    COALIDE_REPORT_TIME               "HH:MM" 24h local time, default "00:00"
+    COALIDE_REPORT_ENABLED            "true"/"false"; defaults to on when a token
+                                      and chat id are both present
+
+The daily report is skipped silently when no token/chat is configured.
+"""
+
+import json
+import os
+import threading
+import time
+import urllib.parse
+import urllib.request
+from datetime import date, datetime, timedelta
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+GUARD_FILE = os.path.join(BASE_DIR, "data", ".last_report")
+
+TELEGRAM_MAX = 4096  # hard API limit on message length
+
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+
+def _parse_env_file(path: str) -> dict:
+    env = {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                env[k.strip()] = v.strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return env
+
+
+def _looks_like_placeholder(v: str) -> bool:
+    if not v:
+        return True
+    bad = ("ENTER_YOUR_TOKEN", "YOUR_CHAT_ID", "IP-TO-YOUR", "YOUR-PARENT-SERVER")
+    return v.startswith("[") or any(b in v for b in bad)
+
+
+def load_settings(host: str, port: int) -> dict:
+    """Resolve report settings from env vars, then a nearby .env, then defaults."""
+    file_env = {}
+    for p in (os.path.join(BASE_DIR, ".env"),
+              os.path.join(os.path.dirname(BASE_DIR), ".env")):
+        for k, v in _parse_env_file(p).items():
+            file_env.setdefault(k, v)
+
+    def get(*keys, default=None):
+        for k in keys:
+            if os.environ.get(k):
+                return os.environ[k]
+        for k in keys:
+            if file_env.get(k):
+                return file_env[k]
+        return default
+
+    token = get("TELEGRAM_BOT_TOKEN", "BOT_TOKEN")
+    chat = get("TELEGRAM_CHAT_ID", "CHAT_ID")
+    if _looks_like_placeholder(token):
+        token = None
+    if _looks_like_placeholder(chat):
+        chat = None
+
+    shown_host = host if host not in ("0.0.0.0", "") else "localhost"
+    url = get("COALIDE_DASHBOARD_URL", default=f"http://{shown_host}:{port}/")
+    report_time = get("COALIDE_REPORT_TIME", default="00:00").strip()
+    try:
+        hh, mm = report_time.split(":")
+        report_time = f"{int(hh):02d}:{int(mm):02d}"
+    except (ValueError, AttributeError):
+        report_time = "00:00"
+
+    enabled_raw = get("COALIDE_REPORT_ENABLED")
+    if enabled_raw is None:
+        enabled = bool(token and chat)
+    else:
+        enabled = enabled_raw.strip().lower() in ("1", "true", "yes", "on")
+
+    return {
+        "token": token,
+        "chat": chat,
+        "url": url,
+        "report_time": report_time,
+        "enabled": enabled and bool(token and chat),
+    }
+
+
+# --------------------------------------------------------------------------
+# Report text
+# --------------------------------------------------------------------------
+
+def _esc(v) -> str:
+    """Escape for Telegram HTML parse mode."""
+    return (str("" if v is None else v)
+            .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def _num(v):
+    try:
+        f = float(v)
+        return int(f) if f == int(f) else round(f, 1)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _today_answers(stats: dict):
+    """(correct, wrong, blank) from the last day of daily_answers."""
+    da = stats.get("daily_answers") or []
+    if not da:
+        return 0, 0, 0
+    parts = da[-1][1] if isinstance(da[-1], (list, tuple)) and len(da[-1]) > 1 else []
+    def part(i):
+        try:
+            return _num(parts[i][0])
+        except (IndexError, TypeError):
+            return 0
+    return part(0), part(1), part(2)
+
+
+def build_report_text(records: list, dashboard_url: str) -> str:
+    """Compose the full daily-report message from stored per-user records."""
+    lines = ["📊 <b>Coalide Günlük Rapor</b>",
+             f"🗓 {date.today().isoformat()}", ""]
+
+    active = [r for r in records if isinstance(r, dict) and r.get("stats")]
+    if not active:
+        lines.append("Henüz hiçbir öğrenci için veri yok.")
+    for rec in active:
+        st = rec.get("stats") or {}
+        name = rec.get("username", "?")
+        tc, tw, tb = _today_answers(st)
+        block = [
+            f"👤 <b>{_esc(name)}</b>",
+            f"🎯 Başarı: {_num(st.get('overall_rate'))}%  ·  💬 {_num(st.get('log_total'))} cevap",
+            f"🔥 Seri: {_num(st.get('streak'))} gün  ·  "
+            f"📚 {_num(st.get('started_count'))}/{_num(st.get('total_words'))} kelime "
+            f"(🏆 {_num(st.get('mastered'))} öğrenilen)",
+            f"✨ Bugün: +{_num(st.get('new_today'))} yeni kelime · "
+            f"{tc + tw + tb} cevap ({tc}✓ {tw}✗ {tb}∅)",
+            f"⏰ Tekrar bekleyen: {_num(st.get('due_now'))}",
+            f"💵 Kredi: {_num(st.get('balance'))}  ·  "
+            f"📺 Bugün ekran süresi: {_num(st.get('redeemed_today'))} dk",
+            f"🪙 Bu hafta: +{_num(st.get('earned_week'))} kazanıldı / "
+            f"−{_num(st.get('spent_week'))} harcandı",
+        ]
+        hardest = st.get("hardest") or []
+        if hardest:
+            hw = ", ".join(f"{_esc(h.get('word'))} (%{_num(h.get('rate'))})"
+                           for h in hardest[:3])
+            block.append(f"🧗 Zorlandığı kelimeler: {hw}")
+        last = rec.get("client_time") or rec.get("updated_at")
+        if last:
+            block.append(f"<i>Son güncelleme: {_esc(last)}</i>")
+        lines.append("\n".join(block))
+        lines.append("")
+
+    lines.append(f"🔗 Daha fazla bilgi: {dashboard_url}")
+    text = "\n".join(lines)
+    if len(text) > TELEGRAM_MAX - 40:
+        text = text[:TELEGRAM_MAX - 60].rstrip() + "\n…\n🔗 " + dashboard_url
+    return text
+
+
+# --------------------------------------------------------------------------
+# Sending
+# --------------------------------------------------------------------------
+
+def send_telegram(text: str, token: str, chat_id: str) -> tuple:
+    """Send `text` to Telegram. Returns (ok: bool, detail: str)."""
+    api = f"https://api.telegram.org/bot{token}/sendMessage"
+    data = urllib.parse.urlencode({
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": "HTML",
+        "disable_web_page_preview": "true",
+    }).encode("utf-8")
+    try:
+        req = urllib.request.Request(api, data=data)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read().decode("utf-8", "replace")
+            ok = resp.status == 200 and '"ok":true' in body.replace(" ", "")
+            return ok, body[:300]
+    except Exception as e:
+        return False, str(e)
+
+
+def run_report(records_provider, settings: dict, log=print) -> bool:
+    """Build and send the report now. Returns True on success."""
+    if not settings.get("enabled"):
+        log("Report skipped: Telegram not configured.")
+        return False
+    records = records_provider() or []
+    text = build_report_text(records, settings["url"])
+    ok, detail = send_telegram(text, settings["token"], settings["chat"])
+    if ok:
+        log(f"Daily report sent to Telegram chat {settings['chat']}.")
+    else:
+        log(f"Daily report FAILED to send: {detail}")
+    return ok
+
+
+# --------------------------------------------------------------------------
+# Scheduler
+# --------------------------------------------------------------------------
+
+def _read_guard() -> str:
+    try:
+        with open(GUARD_FILE, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def _write_guard(day: str) -> None:
+    try:
+        os.makedirs(os.path.dirname(GUARD_FILE), exist_ok=True)
+        with open(GUARD_FILE, "w", encoding="utf-8") as f:
+            f.write(day)
+    except OSError:
+        pass
+
+
+def start_scheduler(records_provider, settings_loader, log=print) -> None:
+    """Start a daemon thread that sends the report once per day.
+
+    `settings_loader` is a no-arg callable returning fresh settings, so changes
+    made through the web admin's .env editor take effect without a restart.
+
+    Fires at the first check that is at or after `report_time` on a day the
+    report hasn't been sent yet — so a report still goes out even if the
+    machine was asleep at the exact minute (e.g. midnight)."""
+
+    def loop():
+        while True:
+            try:
+                settings = settings_loader()
+                if settings.get("enabled"):
+                    now = datetime.now()
+                    today = now.date().isoformat()
+                    if _read_guard() != today and now.strftime("%H:%M") >= settings["report_time"]:
+                        run_report(records_provider, settings, log)
+                        _write_guard(today)  # once per day, success or not
+            except Exception as e:
+                log(f"Report scheduler error: {e}")
+            time.sleep(30)
+
+    threading.Thread(target=loop, name="coalide-daily-report", daemon=True).start()
+    log("Daily Telegram report scheduler started (checks every 30s).")

--- a/serverside/server.py
+++ b/serverside/server.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+Coalide — parental stats server (server side, for the parent).
+
+A tiny, zero-dependency HTTP server (stdlib only) that:
+
+  * receives learning-stats snapshots pushed by the child's Coalide app
+    (POST /api/stats), one stored record per user, and
+  * serves a web dashboard (GET /) that shows all of those stats — the same
+    information as the in-app "İstatistikler" screen, in the browser.
+
+The child's app pushes a fresh snapshot every time its menu opens (see
+stats_reporter.py in the main project), so the dashboard stays current without
+the parent needing any access to the child's machine.
+
+Run it on the parent's machine / a always-on box:
+
+    python server.py                 # listens on 0.0.0.0:5055
+    COALIDE_STATS_PORT=8000 python server.py
+
+Then point the child's config.json "STATS_SERVER_URL" at this host, e.g.
+    "STATS_SERVER_URL": "http://192.168.1.50:5055"
+
+Data is stored as plain JSON under ./data/<user>.json. Nothing here ships in a
+Coalide release — the whole `serverside/` folder is wiped by `-release-ready`.
+"""
+
+import json
+import os
+import re
+import sys
+import threading
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import report      # daily Telegram report (stdlib-only, sits next to this file)
+import admin_api    # admin auth + config/words sync backend
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+DASHBOARD_FILE = os.path.join(BASE_DIR, "dashboard.html")
+ADMIN_FILE_HTML = os.path.join(BASE_DIR, "admin.html")
+
+HOST = os.environ.get("COALIDE_STATS_HOST", "0.0.0.0")
+PORT = int(os.environ.get("COALIDE_STATS_PORT", "5055"))
+
+MAX_BODY_BYTES = 12 * 1024 * 1024  # 12 MB — words.json sync can be a few hundred KB
+
+# Usernames end up in a filename; keep only safe characters (Unicode word
+# chars + hyphen), matching utils._sanitize_username in the main project.
+_UNSAFE_RE = re.compile(r"[^\w\-]", re.UNICODE)
+
+_lock = threading.Lock()  # serialize reads/writes of the JSON store
+
+
+# --------------------------------------------------------------------------
+# Storage
+# --------------------------------------------------------------------------
+
+def _safe_user(name: str) -> str:
+    return _UNSAFE_RE.sub("", (name or "").strip()) or "default"
+
+
+def _user_path(user: str) -> str:
+    return os.path.join(DATA_DIR, f"{_safe_user(user)}.json")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _save_record(user: str, record: dict) -> None:
+    os.makedirs(DATA_DIR, exist_ok=True)
+    path = _user_path(user)
+    tmp = path + ".tmp"
+    with _lock:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(record, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)  # atomic on the same filesystem
+
+
+def _load_record(user: str):
+    path = _user_path(user)
+    with _lock:
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+
+def _list_users() -> list:
+    if not os.path.isdir(DATA_DIR):
+        return []
+    users = []
+    for fname in os.listdir(DATA_DIR):
+        if not fname.endswith(".json"):
+            continue
+        rec = _load_record(fname[:-5])
+        if not isinstance(rec, dict):
+            continue
+        users.append({
+            "username": rec.get("username", fname[:-5]),
+            "updated_at": rec.get("updated_at"),
+            "client_time": rec.get("client_time"),
+        })
+    users.sort(key=lambda u: u.get("updated_at") or "", reverse=True)
+    return users
+
+
+def all_records() -> list:
+    """Every stored per-user record (used by the daily report)."""
+    if not os.path.isdir(DATA_DIR):
+        return []
+    out = []
+    for fname in sorted(os.listdir(DATA_DIR)):
+        if not fname.endswith(".json"):
+            continue
+        rec = _load_record(fname[:-5])
+        if isinstance(rec, dict):
+            out.append(rec)
+    return out
+
+
+# --------------------------------------------------------------------------
+# HTTP handler
+# --------------------------------------------------------------------------
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "CoalideStats/1.0"
+
+    # ---- helpers ----
+    def _send_json(self, obj, status=200):
+        body = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_bytes(self, body: bytes, content_type: str, status=200):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_html_file(self, path, missing):
+        try:
+            with open(path, "rb") as f:
+                self._send_bytes(f.read(), "text/html; charset=utf-8")
+        except FileNotFoundError:
+            self._send_bytes(missing, "text/plain; charset=utf-8", status=500)
+
+    def _read_json(self):
+        """Read and parse a JSON request body. Returns (obj, error_response_sent)."""
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except (TypeError, ValueError):
+            length = 0
+        if length <= 0:
+            self._send_json({"error": "empty body"}, status=400)
+            return None
+        if length > MAX_BODY_BYTES:
+            self._send_json({"error": "payload too large"}, status=413)
+            return None
+        try:
+            obj = json.loads(self.rfile.read(length).decode("utf-8"))
+        except Exception:
+            self._send_json({"error": "invalid JSON"}, status=400)
+            return None
+        if not isinstance(obj, dict):
+            self._send_json({"error": "expected a JSON object"}, status=400)
+            return None
+        return obj
+
+    def _admin_token(self):
+        return (self.headers.get("X-Admin-Token")
+                or parse_qs(urlparse(self.path).query).get("token", [None])[0])
+
+    def _require_admin(self) -> bool:
+        """Return True if the request carries a valid admin token, else 401."""
+        if admin_api.valid_token(self._admin_token()):
+            return True
+        self._send_json({"error": "unauthorized"}, status=401)
+        return False
+
+    # ---- routing ----
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        qs = parse_qs(parsed.query)
+
+        if path in ("/", "/index.html", "/dashboard.html"):
+            return self._send_html_file(DASHBOARD_FILE,
+                                        b"dashboard.html not found next to server.py")
+
+        if path in ("/admin", "/admin.html"):
+            return self._send_html_file(ADMIN_FILE_HTML,
+                                        b"admin.html not found next to server.py")
+
+        if path == "/health":
+            return self._send_json({"status": "ok", "time": _now_iso()})
+
+        if path == "/api/users":
+            return self._send_json({"users": _list_users()})
+
+        # ---- admin (auth required) ----
+        if path == "/api/admin/coalide-config":
+            if not self._require_admin():
+                return
+            return self._send_json(admin_api.get_config_state())
+
+        if path == "/api/admin/words":
+            if not self._require_admin():
+                return
+            return self._send_json(admin_api.get_words_state())
+
+        if path == "/api/admin/server-env":
+            if not self._require_admin():
+                return
+            return self._send_json(admin_api.get_server_env())
+
+        if path == "/api/report/preview":
+            settings = report.load_settings(HOST, PORT)
+            text = report.build_report_text(all_records(), settings["url"])
+            return self._send_json({"enabled": settings["enabled"],
+                                    "report_time": settings["report_time"],
+                                    "text": text})
+
+        if path == "/api/stats":
+            user = (qs.get("user") or [None])[0]
+            if not user:
+                users = _list_users()
+                if not users:
+                    return self._send_json({"error": "no data yet"}, status=404)
+                user = users[0]["username"]  # most recently updated
+            record = _load_record(user)
+            if record is None:
+                return self._send_json({"error": f"no data for '{user}'"}, status=404)
+            return self._send_json(record)
+
+        return self._send_json({"error": "not found"}, status=404)
+
+    def do_POST(self):
+        path = urlparse(self.path).path.rstrip("/") or "/"
+
+        if path == "/api/stats":
+            return self._post_stats()
+        if path == "/api/sync":
+            return self._post_sync()
+        if path == "/api/admin/login":
+            return self._post_login()
+        if path == "/api/admin/logout":
+            admin_api.logout(self._admin_token())
+            return self._send_json({"status": "ok"})
+        if path == "/api/admin/coalide-config":
+            return self._post_config()
+        if path == "/api/admin/words":
+            return self._post_words()
+        if path == "/api/admin/server-env":
+            return self._post_server_env()
+
+        return self._send_json({"error": "not found"}, status=404)
+
+    # ---- POST handlers ----
+    def _post_stats(self):
+        payload = self._read_json()
+        if payload is None:
+            return
+        user = _safe_user(payload.get("username", "default"))
+        record = {
+            "username": user,
+            "client_time": payload.get("client_time"),
+            "updated_at": _now_iso(),
+            "stats": payload.get("stats", {}),
+        }
+        try:
+            _save_record(user, record)
+        except Exception as e:
+            return self._send_json({"error": f"could not store: {e}"}, status=500)
+        return self._send_json({"status": "ok", "username": user,
+                                "updated_at": record["updated_at"]}, status=201)
+
+    def _post_sync(self):
+        payload = self._read_json()
+        if payload is None:
+            return
+        try:
+            return self._send_json(admin_api.sync(payload))
+        except Exception as e:
+            return self._send_json({"error": f"sync failed: {e}"}, status=500)
+
+    def _post_login(self):
+        payload = self._read_json()
+        if payload is None:
+            return
+        token, err = admin_api.login(payload.get("hash", ""))
+        if token:
+            return self._send_json({"token": token})
+        status = 503 if err == "not_synced" else 401
+        return self._send_json({"error": err}, status=status)
+
+    def _post_config(self):
+        if not self._require_admin():
+            return
+        payload = self._read_json()
+        if payload is None:
+            return
+        try:
+            rev = admin_api.save_config(payload.get("config"))
+        except Exception as e:
+            return self._send_json({"error": str(e)}, status=400)
+        return self._send_json({"status": "ok", "rev": rev})
+
+    def _post_words(self):
+        if not self._require_admin():
+            return
+        payload = self._read_json()
+        if payload is None:
+            return
+        action = payload.get("action")
+        try:
+            if action == "add":
+                result = admin_api.add_word(payload.get("word") or {})
+            elif action == "edit":
+                result = admin_api.edit_word(int(payload.get("index", -1)),
+                                             payload.get("word") or {})
+            elif action == "delete":
+                result = admin_api.delete_word(int(payload.get("index", -1)))
+            else:
+                return self._send_json({"error": "unknown action"}, status=400)
+        except Exception as e:
+            return self._send_json({"error": str(e)}, status=400)
+        return self._send_json({"status": "ok", **result})
+
+    def _post_server_env(self):
+        if not self._require_admin():
+            return
+        payload = self._read_json()
+        if payload is None:
+            return
+        try:
+            admin_api.save_server_env(payload.get("env") or {})
+        except Exception as e:
+            return self._send_json({"error": str(e)}, status=400)
+        return self._send_json({"status": "ok"})
+
+    # Quieter, single-line access log.
+    def log_message(self, fmt, *args):
+        print(f"[{self.log_date_time_string()}] {self.address_string()} "
+              f"{fmt % args}")
+
+
+def main():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    httpd = ThreadingHTTPServer((HOST, PORT), Handler)
+    shown_host = HOST if HOST != "0.0.0.0" else "localhost"
+    print("Coalide parental stats server")
+    print(f"  Dashboard : http://{shown_host}:{PORT}/")
+    print(f"  Admin     : http://{shown_host}:{PORT}/admin")
+    print(f"  API       : http://{shown_host}:{PORT}/api/stats")
+    print(f"  Data dir  : {DATA_DIR}")
+    # Daily Telegram report scheduler — reloads settings each cycle, so .env
+    # edits via the web admin take effect without a restart (no-op if unset).
+    report.start_scheduler(all_records, lambda: report.load_settings(HOST, PORT))
+    print("  Press Ctrl+C to stop.\n")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    # Manual helpers for setup/testing:
+    #   python server.py --report-preview   print the report text, don't send
+    #   python server.py --send-report      send the report now via Telegram
+    if "--report-preview" in sys.argv[1:]:
+        st = report.load_settings(HOST, PORT)
+        print(report.build_report_text(all_records(), st["url"]))
+        sys.exit(0)
+    if "--send-report" in sys.argv[1:]:
+        st = report.load_settings(HOST, PORT)
+        ok = report.run_report(all_records, st)
+        sys.exit(0 if ok else 1)
+    main()

--- a/stats_reporter.py
+++ b/stats_reporter.py
@@ -1,0 +1,124 @@
+"""
+Coalide — parental stats reporter (client side).
+
+Pushes a snapshot of the local learning statistics to the parent-side web
+dashboard / API (see the `serverside/` folder) so a parent can watch progress
+remotely. The main program calls report_stats_async() when the menu opens, so
+the dashboard always reflects the latest state.
+
+Design goals (mirrors stats_menu.record_answer's "never break the app" rule):
+  - Fully non-blocking: the push runs in a daemon thread with a short timeout.
+  - Silent on failure: no server, offline, bad URL -> nothing happens, no crash.
+  - Opt-in by configuration: does nothing until STATS_SERVER_URL is set to a
+    real address (the placeholder default is ignored).
+
+The payload is whatever stats_menu.build_stats() produces, run through a small
+recursive JSON serializer so dates / Counters / tuples survive the trip. This
+keeps the statistics logic in exactly one place (stats_menu) — the server and
+dashboard just render what they are given.
+"""
+
+import json
+import os
+import threading
+from collections import Counter
+from datetime import date, datetime
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CURRENT_USER_FILE = os.path.join(BASE_DIR, "current_user.json")
+
+# If STATS_SERVER_URL still contains one of these, treat it as "not configured"
+# and skip reporting entirely (so the shipped placeholder never hits the wire).
+_PLACEHOLDER_MARKERS = ("IP-TO-YOUR", "YOUR-PARENT-SERVER", "example.com")
+
+_REQUEST_TIMEOUT = 4  # seconds — a parent server should answer fast or not at all
+
+
+def _jsonable(obj):
+    """Recursively convert build_stats() output into JSON-serializable data."""
+    if isinstance(obj, (date, datetime)):
+        return obj.isoformat()
+    if isinstance(obj, Counter):
+        return {str(k): _jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, dict):
+        return {str(k): _jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_jsonable(v) for v in obj]
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    return str(obj)  # last-resort: never let an odd type break the push
+
+
+def _current_username() -> str:
+    """Read the logged-in username directly (no prompt, no heavy imports)."""
+    try:
+        with open(CURRENT_USER_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict) and data.get("username"):
+            return str(data["username"])
+    except Exception:
+        pass
+    return "default"
+
+
+def _build_payload() -> dict:
+    from stats_menu import build_stats  # local import: pulls textual, keep lazy
+    stats = build_stats()
+    return {
+        "username": _current_username(),
+        "client_time": datetime.now().isoformat(timespec="seconds"),
+        "stats": _jsonable(stats),
+    }
+
+
+def _push() -> None:
+    """Build and POST the stats snapshot. Swallows every error by design."""
+    try:
+        from utils import get_config, lg
+    except Exception:
+        return
+
+    try:
+        cfg = get_config()
+        if not cfg.get("STATS_REPORTING_ENABLED", True):
+            return
+
+        url = str(cfg.get("STATS_SERVER_URL", "")).strip()
+        if not url or any(marker in url for marker in _PLACEHOLDER_MARKERS):
+            lg("stats_reporter: STATS_SERVER_URL not configured, skipping push.")
+            return
+
+        endpoint = url.rstrip("/") + "/api/stats"
+        payload = _build_payload()
+
+        import requests
+        resp = requests.post(endpoint, json=payload, timeout=_REQUEST_TIMEOUT,
+                             headers={"Content-Type": "application/json"})
+        if resp.status_code in (200, 201):
+            lg(f"stats_reporter: pushed stats for '{payload['username']}'.")
+        else:
+            lg(f"stats_reporter: server returned {resp.status_code}: {resp.text[:200]}")
+    except Exception as e:
+        # Never surface reporting failures to the learner — it's a background
+        # convenience for the parent, not part of the quiz flow.
+        try:
+            lg(f"stats_reporter: push failed: {e}")
+        except Exception:
+            pass
+
+
+def report_stats_async() -> threading.Thread:
+    """Fire-and-forget the stats push on a daemon thread; returns the thread."""
+    t = threading.Thread(target=_push, name="coalide-stats-reporter", daemon=True)
+    t.start()
+    return t
+
+
+if __name__ == "__main__":
+    # Manual test: build the payload and either print it or push it.
+    import sys
+    if "--push" in sys.argv[1:]:
+        _push()
+        print("Push attempted (see debug log with -debug for details).")
+    else:
+        print(json.dumps(_build_payload(), indent=2, ensure_ascii=False))

--- a/utils.py
+++ b/utils.py
@@ -60,7 +60,10 @@ def get_config(default=False):
         "BYPASS_SHORTCUTS":True,
         "Credit_Window_Start":"07:00",
         "Credit_Window_End":"22:00",
-        "REQUIRE_INTERNET":True
+        "REQUIRE_INTERNET":True,
+        "STATS_REPORTING_ENABLED":True,
+        "STATS_SERVER_URL":"http://IP-TO-YOUR-PARENT-SERVER:5055",
+        "CONFIG_SYNC_ENABLED":True
 
     }
     if not os.path.exists(config_path):


### PR DESCRIPTION
Adds a zero-dependency (stdlib-only) parent-side server under serverside/ that the child's Coalide app talks to over HTTP:

- Web dashboard mirroring the in-app statistics screen, with inline-SVG charts (line/area, grouped columns, donut, progress ring, sequential distribution) and hover tooltips.
- Stats API: the app pushes a snapshot when the menu opens (stats_reporter.py).
- Daily Telegram report at a configured time (default midnight) summarizing every learner's data, ending with a link to the dashboard (report.py).
- Password-gated web admin (admin.html / admin_api.py) to manage Coalide's config.json and words.json and the server's own .env. Since the server runs on a different device, changes flow through a sync API: the child pushes its config/words + a hash of ADMIN_PASSWORD on each menu open and pulls back any parent edits by revision number, applying them locally (config_sync.py). The admin password is hashed in the browser; plaintext never hits the server.

Client wiring: menu.py fires sync + stats push on menu open; utils.py adds STATS_REPORTING_ENABLED, STATS_SERVER_URL, CONFIG_SYNC_ENABLED config keys; cli.py -release-ready wipes serverside/ and .config_sync.json.