### PR TITLE
Add SHUFFLE_NEW_WORDS config to randomize new-word order

### DIFF
--- a/serverside/admin_api.py
+++ b/serverside/admin_api.py
@@ -51,6 +51,7 @@ WORD_TYPES = ["noun", "verb", "adjective", "adverb", "pronoun", "preposition", "
 CONFIG_DESCRIPTIONS = {
     "Daily_New_Word_Cap": "Bir günde en fazla kaç yeni kelime tanıtılır.",
     "No_Repeat_Window": "Aynı kelime tekrar sorulmadan önce kaç soru geçmeli.",
+    "SHUFFLE_NEW_WORDS": "Yeni kelimeler liste sırasıyla değil rastgele tanıtılsın mı.",
     "Repo_Owner": "Güncellemelerin indirildiği GitHub kullanıcısı.",
     "Repo_Name": "Güncellemelerin indirildiği GitHub deposu.",
     "Update_Prereleases": "Ön sürüm (beta) güncellemeleri de yüklensin mi.",

--- a/sm2.py
+++ b/sm2.py
@@ -15,11 +15,35 @@ config = get_config()
 
 DAILY_NEW_WORD_CAP = config.get("Daily_New_Word_Cap", 15) # how many brand-new words can be introduced per day
 NO_REPEAT_WINDOW = config.get("No_Repeat_Window", 8) # a word can't repeat within this many questions
+SHUFFLE_NEW_WORDS = config.get("SHUFFLE_NEW_WORDS", False) # introduce new words in random order instead of words.json order
+
+NEW_WORD_SENTINEL = "2020-10-10" # next_review_date assigned to brand-new (never-reviewed) words
+
+
+def _order_word_list(words: list[Word]):
+    """
+    Sort words by next_review_date (earliest first) in place.
+
+    Brand-new words all share NEW_WORD_SENTINEL, the earliest possible date, so
+    they land at the front of the list. By default they stay in words.json order;
+    when SHUFFLE_NEW_WORDS is enabled we shuffle just those new words among
+    themselves so they're introduced in a random order. Because every downstream
+    sort is a stable sort on the same key, this randomized order is preserved
+    throughout the session.
+    """
+    words.sort(key=attrgetter('next_review_date')) # sort by next review date, earliest first
+    if SHUFFLE_NEW_WORDS:
+        new_words = [w for w in words if w.next_review_date == NEW_WORD_SENTINEL]
+        if len(new_words) > 1:
+            random.shuffle(new_words)
+            others = [w for w in words if w.next_review_date != NEW_WORD_SENTINEL]
+            words[:] = new_words + others
+    return words
 
 
 word_list = get_words("words.json")
 lg(word_list)
-word_list.sort(key=attrgetter('next_review_date')) # sort by next review date, earliest first
+_order_word_list(word_list)
 
 # if the word is new, it's next_review_date will equal to "00-00-01" which is the earliest possible date, so it will be at the front of the list
 
@@ -32,7 +56,7 @@ def reload_words():
     """
     global word_list
     word_list = get_words("words.json")
-    word_list.sort(key=attrgetter('next_review_date'))
+    _order_word_list(word_list)
 
 def _fallback_pool(cap_reached: bool):
     """

--- a/utils.py
+++ b/utils.py
@@ -45,6 +45,7 @@ def get_config(default=False):
     default_config = {
         "Daily_New_Word_Cap":15,
         "No_Repeat_Window":8,
+        "SHUFFLE_NEW_WORDS":False,
         "Repo_Owner":"MelihAydinYanibol",
         "Repo_Name":"Coalide",
         "Update_Prereleases":False,


### PR DESCRIPTION
## Summary
Adds an opt-in `SHUFFLE_NEW_WORDS` config key that introduces brand-new words in random order instead of `words.json` file order. Defaults to `false`, so existing behavior is unchanged.

## Changes
- **utils.py** — added `"SHUFFLE_NEW_WORDS": False` to the default config. The existing `_merge_missing_config_keys` logic auto-adds it to existing `config.json` files, so no manual migration is needed.
- **sm2.py** — added a `_order_word_list()` helper (used at module load and in `reload_words()`). When enabled, it shuffles only the new words (those still on the `"2020-10-10"` sentinel date) at the front of the list. Because every downstream sort is a **stable** sort on the same key, the randomized order is preserved throughout the session.
- **serverside/admin_api.py** — added a Turkish description so the toggle appears in the parent admin panel.

## Behavior
- Shuffle happens once per session (consistent while studying, random across sessions).
- Daily new-word cap, no-repeat window, and spaced-repetition scheduling for reviewed words are all unaffected — only *new* word introduction order changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)