### PR TITLE
Web app: terminal-user importer + full per-user statistics

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,5 +1,6 @@
-# Per-user runtime data (progress + credit balances)
+# Per-user runtime data (progress, credit balances, config overlays, answer logs)
 data/*.json
+data/*.csv
 !data/.gitkeep
 
 __pycache__/

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -113,6 +113,24 @@ Environment variables:
 | `ADMIN_PASSWORD` | Admin dashboard password (also read from `../.env`) | `0000` |
 | `COALIDE_DEBUG` | Set to enable Flask debug mode | off |
 
+### Importing a terminal user
+
+To bring a learner's existing terminal-app data into the web app, use the
+bundled importer instead of renaming by hand (it also fixes the `"username"`
+field inside the credits file, which a plain rename would leave stale):
+
+```bash
+cd webapp
+python import_user.py <username> <folder-with-their-files> [--config] [--force]
+# e.g.  python import_user.py mert D:\pack
+```
+
+It reads `progress.json` → `data/<user>_progress.json`, `*_data.json` →
+`data/<user>_data.json`, and (with `--config`) imports `config.json` as a
+per-user overlay pruned to just the keys that differ from the shared root.
+`statistics.csv`, `version.json` and `words.json` are ignored — the web app
+doesn't use them. Then log in as that user.
+
 ## How it maps to the terminal app
 
 | Terminal app | Web app |

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -27,8 +27,12 @@ browser, with **per-user progress** kept separately for each learner.
 - **Pronunciation** — the target word and example sentence are read aloud using
   the browser's built-in Web Speech API, so no TTS keys or server-side audio are
   required. (The terminal app's ElevenLabs/gTTS pipeline is not needed here.)
-- **Stats dashboard** — words seen, due now, well-known count and overall
-  success rate.
+- **Full statistics dashboard** — a browser port of the terminal
+  İstatistikler screen, with the same five tabs (Genel Bakış, Krediler,
+  Haftalık & Günlük, Kelimeler, Gelecek & SM-2): overview tiles, SM-2 maturity
+  buckets, hardest words, daily/weekly new-word and answer charts, activity
+  sparklines, credit earn/spend/redeem history, a per-word table and SM-2
+  health. Every answer is logged per-user to `webapp/data/<user>_stats.csv`.
 - **Admin dashboard** — a password-protected parent panel at `/admin`,
   connected to the web app's own data: see every learner's progress and
   balance, adjust credits, and edit the shared `config.json` from the browser.
@@ -139,6 +143,8 @@ doesn't use them. Then log in as that user.
 | `objects/word_obj.py` (`Word`, progress) | reuses `Word`; progress persisted per-user in `engine.py` |
 | `new_master.normalize_answer` | `engine.normalize_answer` |
 | `objects/balance_obj.py` (credits/pricing) | `credits.py` |
+| `stats_menu.build_stats` / `record_answer` | `stats.build_stats` / `stats.record_answer` |
+| `statistics.csv` (global answer log) | `webapp/data/<user>_stats.csv` (per-user) |
 | `current_user.json` | Flask session cookie |
 | ElevenLabs / gTTS audio | browser Web Speech API |
 
@@ -156,9 +162,11 @@ would restore the real grant.
 
 ```
 webapp/
-├── app.py            # Flask app: pages + JSON API (quiz + admin)
+├── app.py            # Flask app: pages + JSON API (quiz + admin + stats)
 ├── engine.py         # per-user SM-2 learning engine (reuses words.json + Word)
 ├── credits.py        # per-user credit earning / pricing / redemption
+├── stats.py          # per-user answer log + build_stats (İstatistikler port)
+├── import_user.py    # bring a terminal user's files into webapp/data/
 ├── requirements.txt
 ├── templates/
 │   ├── login.html
@@ -167,8 +175,9 @@ webapp/
 ├── static/
 │   ├── style.css
 │   ├── app.js        # quiz front-end logic
+│   ├── stats.js      # statistics dashboard renderer
 │   └── admin.js      # admin dashboard logic
-└── data/             # per-user progress + balances (gitignored)
+└── data/             # per-user progress + balances + stats logs (gitignored)
 ```
 
 ## Production note

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -21,6 +21,7 @@ from flask import Flask, jsonify, redirect, render_template, request, session, u
 
 import engine
 import credits
+import stats
 
 DEFAULT_PORT = 6656
 
@@ -193,6 +194,7 @@ def api_answer():
     is_target_wanted = pending["is_target_wanted"]
     result = engine.grade_answer(word, is_target_wanted, answer, time_taken)
     engine.save_word_progress(user, word)
+    stats.record_answer(user, word.target, result["is_correct"])  # per-user answer log
 
     # Credits for a correct answer (respects the earning window).
     credit_info = {"awarded": 0, "balance": credits.load_user(user)["balance"], "in_window": True}
@@ -216,12 +218,23 @@ def api_answer():
 @app.route("/api/stats", methods=["GET"])
 @login_required
 def api_stats():
+    """Lightweight summary used by the header pill and rewards screen."""
     user = current_user()
     data = credits.load_user(user)
     credits.check_weekly_reset(data)
-    stats = engine.user_stats(user)
-    stats["balance"] = data["balance"]
-    return jsonify(stats)
+    summary = engine.user_stats(user)
+    summary["balance"] = data["balance"]
+    return jsonify(summary)
+
+
+@app.route("/api/stats/full", methods=["GET"])
+@login_required
+def api_stats_full():
+    """Full statistics dashboard payload (ports the terminal İstatistikler screen)."""
+    user = current_user()
+    data = credits.load_user(user)
+    credits.check_weekly_reset(data)
+    return jsonify(stats.build_stats(user))
 
 
 @app.route("/api/redeem", methods=["POST"])

--- a/webapp/engine.py
+++ b/webapp/engine.py
@@ -67,6 +67,15 @@ def _read_json_dict(path: str) -> dict:
         return {}
 
 
+def _read_json_list(path: str) -> list:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+        return loaded if isinstance(loaded, list) else []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
 def _root_config_path() -> str:
     return os.path.join(PROJECT_ROOT, "config.json")
 

--- a/webapp/import_user.py
+++ b/webapp/import_user.py
@@ -18,11 +18,12 @@ What it does, looking inside <source_folder>:
 
     progress.json           ->  webapp/data/<username>_progress.json
     <any>_data.json / data.json ->  webapp/data/<username>_data.json  (username field fixed)
+    statistics.csv          ->  webapp/data/<username>_stats.csv  (per-answer log)
     config.json  (only with --config) -> webapp/data/<username>_config.json
                                           pruned to just the keys that differ
                                           from the shared root config.json
 
-    statistics.csv, version.json, words.json  ->  skipped (the web app doesn't use them)
+    version.json, words.json  ->  skipped (the web app doesn't use them)
 
 Existing destination files are left alone unless you pass --force.
 """
@@ -113,7 +114,25 @@ def import_user(username: str, src: str, with_config: bool = False, force: bool 
     else:
         skipped.append("no *_data.json found")
 
-    # 3) config.json -> <username>_config.json  (opt-in, pruned to real overrides)
+    # 3) statistics.csv -> <username>_stats.csv  (per-answer log; also accept a prefixed name)
+    import shutil
+    stats_src = next((os.path.join(src, n) for n in
+                      (f"{username}_stats.csv", "statistics.csv")
+                      if os.path.exists(os.path.join(src, n))), None)
+    if stats_src:
+        dst = os.path.join(engine.DATA_DIR, f"{username}_stats.csv")
+        if guard(dst):
+            try:
+                with open(stats_src, "r", encoding="utf-8") as f:
+                    rows = sum(1 for _ in f)
+                shutil.copyfile(stats_src, dst)
+                did.append(f"answer log ({max(0, rows - 1)} answers) -> {os.path.basename(dst)}")
+            except OSError as e:
+                skipped.append(f"stats log: {e}")
+    else:
+        skipped.append("no statistics.csv found")
+
+    # 4) config.json -> <username>_config.json  (opt-in, pruned to real overrides)
     config_src = os.path.join(src, "config.json")
     if with_config and os.path.exists(config_src):
         try:

--- a/webapp/import_user.py
+++ b/webapp/import_user.py
@@ -1,0 +1,161 @@
+"""
+Import a terminal-app user's data files into the web app.
+
+The terminal app and the web app use the same per-word / per-user JSON schemas,
+so bringing a learner across is mostly a rename — with one catch this script
+handles for you: the credits file carries a ``"username"`` field that must match
+the target username, or the app would later save to the wrong file.
+
+Usage
+-----
+    python import_user.py <username> <source_folder> [--config] [--force]
+
+Example (Windows)
+    python import_user.py mert D:\\pack
+    python import_user.py mert D:\\pack --config      # also import per-user config
+
+What it does, looking inside <source_folder>:
+
+    progress.json           ->  webapp/data/<username>_progress.json
+    <any>_data.json / data.json ->  webapp/data/<username>_data.json  (username field fixed)
+    config.json  (only with --config) -> webapp/data/<username>_config.json
+                                          pruned to just the keys that differ
+                                          from the shared root config.json
+
+    statistics.csv, version.json, words.json  ->  skipped (the web app doesn't use them)
+
+Existing destination files are left alone unless you pass --force.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+
+import engine  # sits next to this file; gives DATA_DIR, config helpers, _safe_username
+
+
+def _load_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _write_json(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=4)
+
+
+def _find_data_file(src: str) -> str | None:
+    """A *_data.json file (any username), or data.json, in the source folder."""
+    candidates = sorted(glob.glob(os.path.join(src, "*_data.json")))
+    if candidates:
+        return candidates[0]
+    plain = os.path.join(src, "data.json")
+    return plain if os.path.exists(plain) else None
+
+
+def import_user(username: str, src: str, with_config: bool = False, force: bool = False) -> None:
+    username = engine._safe_username(username)
+    if not username:
+        sys.exit("error: invalid username")
+    if not os.path.isdir(src):
+        sys.exit(f"error: source folder not found: {src}")
+
+    os.makedirs(engine.DATA_DIR, exist_ok=True)
+    did, skipped = [], []
+
+    def dest(name):
+        return os.path.join(engine.DATA_DIR, f"{username}_{name}.json")
+
+    def guard(path):
+        if os.path.exists(path) and not force:
+            skipped.append(f"{os.path.basename(path)} already exists (use --force to overwrite)")
+            return False
+        return True
+
+    # 1) progress.json -> <username>_progress.json  (accept an already-prefixed name too)
+    progress_src = next((os.path.join(src, n) for n in
+                         (f"{username}_progress.json", "progress.json")
+                         if os.path.exists(os.path.join(src, n))), None)
+    if progress_src:
+        try:
+            data = _load_json(progress_src)
+            if not isinstance(data, dict):
+                raise ValueError("progress file is not a JSON object")
+            if guard(dest("progress")):
+                _write_json(dest("progress"), data)
+                did.append(f"progress ({len(data)} words) -> {os.path.basename(dest('progress'))}")
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            skipped.append(f"progress: {e}")
+    else:
+        skipped.append("no progress.json found")
+
+    # 2) *_data.json -> <username>_data.json  (fix the internal username field)
+    data_src = _find_data_file(src)
+    if data_src:
+        try:
+            data = _load_json(data_src)
+            if not isinstance(data, dict):
+                raise ValueError("data file is not a JSON object")
+            original = data.get("username")
+            data["username"] = username  # keep the filename and the field in sync
+            data.setdefault("balance", 0)
+            data.setdefault("redeemed_minutes_by_date", {})
+            data.setdefault("last_reset_date", None)
+            if guard(dest("data")):
+                _write_json(dest("data"), data)
+                note = f" (username '{original}' -> '{username}')" if original and original != username else ""
+                did.append(f"credits (balance {data.get('balance', 0)}){note} -> {os.path.basename(dest('data'))}")
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            skipped.append(f"credits: {e}")
+    else:
+        skipped.append("no *_data.json found")
+
+    # 3) config.json -> <username>_config.json  (opt-in, pruned to real overrides)
+    config_src = os.path.join(src, "config.json")
+    if with_config and os.path.exists(config_src):
+        try:
+            incoming = _load_json(config_src)
+            if not isinstance(incoming, dict):
+                raise ValueError("config file is not a JSON object")
+            root = dict(engine.CONFIG_DEFAULTS)
+            root.update(engine._read_json_dict(engine._root_config_path()))
+            # Keep only editable keys whose value differs from the root config,
+            # so the overlay stays minimal and unchanged keys track the root.
+            overlay = {k: v for k, v in incoming.items()
+                       if k in engine.EDITABLE_CONFIG_KEYS and root.get(k) != v}
+            if not overlay:
+                skipped.append("config: nothing differs from root config.json (no overlay needed)")
+            elif guard(dest("config")):
+                _write_json(dest("config"), overlay)
+                did.append(f"config overlay ({', '.join(overlay)}) -> {os.path.basename(dest('config'))}")
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            skipped.append(f"config: {e}")
+    elif os.path.exists(config_src):
+        skipped.append("config.json present but not imported (pass --config to import as per-user overlay)")
+
+    # Report
+    print(f"\nImporting '{username}' from {src}\n" + "-" * 48)
+    for line in did:
+        print("  ✓ " + line)
+    for line in skipped:
+        print("  – " + line)
+    print("-" * 48)
+    print(f"Done. Files written to: {engine.DATA_DIR}")
+    if did:
+        print(f"Log in to the web app as '{username}' to see the imported data.")
+
+
+def main(argv):
+    args = [a for a in argv if not a.startswith("--")]
+    flags = {a for a in argv if a.startswith("--")}
+    if len(args) < 2:
+        print(__doc__)
+        sys.exit(1)
+    import_user(args[0], args[1], with_config="--config" in flags, force="--force" in flags)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -194,16 +194,12 @@
     // Stats
     // --------------------------------------------------------------------- //
     async function loadStats() {
-        const res = await fetch("/api/stats");
-        if (!res.ok) return;
-        const s = await res.json();
-        el("s-seen").textContent = s.words_seen;
-        el("s-total").textContent = s.total_words;
-        el("s-due").textContent = s.due_now;
-        el("s-mastered").textContent = s.mastered;
-        el("s-rate").textContent = "%" + s.overall_rate;
-        el("s-balance").textContent = s.balance;
-        setBalance(s.balance);
+        // Keep the header balance fresh, then render the full dashboard.
+        try {
+            const res = await fetch("/api/stats");
+            if (res.ok) setBalance((await res.json()).balance);
+        } catch (e) { /* ignore */ }
+        if (window.CoalideStats) window.CoalideStats.load();
     }
 
     // --------------------------------------------------------------------- //

--- a/webapp/static/stats.js
+++ b/webapp/static/stats.js
@@ -1,0 +1,324 @@
+/* Coalide — statistics dashboard renderer.
+   Ports the terminal İstatistikler screen (stats_menu.py) to the browser:
+   five sub-tabs (Genel / Krediler / Haftalık & Günlük / Kelimeler / Gelecek). */
+(function () {
+    "use strict";
+
+    const COLORS = { muted: "var(--muted)", red: "var(--red)", yellow: "var(--yellow)",
+                     purple: "var(--purple)", green: "var(--green)" };
+    const col = (t) => COLORS[t] || "var(--muted)";
+
+    let payload = null;
+    let activeSub = "genel";
+
+    // --- tiny DOM helpers ---
+    function h(tag, cls, html) {
+        const e = document.createElement(tag);
+        if (cls) e.className = cls;
+        if (html != null) e.innerHTML = html;
+        return e;
+    }
+    function esc(s) {
+        return String(s).replace(/[&<>"']/g, (c) => (
+            { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+    }
+
+    function tile(label, value, token) {
+        const t = h("div", "stat-tile stat-" + (token || "purple"));
+        t.appendChild(h("span", "stat-tile-num", esc(value)));
+        t.appendChild(h("span", "stat-tile-label", esc(label)));
+        return t;
+    }
+    function tiles(list) {
+        const g = h("div", "stat-tiles");
+        list.forEach(([l, v, t]) => g.appendChild(tile(l, v, t)));
+        return g;
+    }
+
+    function panel(title, token, bodyNode) {
+        const p = h("div", "stat-panel panel-" + (token || "purple"));
+        p.appendChild(h("h3", "stat-panel-title", esc(title)));
+        if (bodyNode) p.appendChild(bodyNode);
+        return p;
+    }
+
+    // horizontal bar chart from [{label,value,color}]
+    function hbar(rows) {
+        const wrap = h("div", "hbar");
+        const max = Math.max(0, ...rows.map((r) => r.value));
+        if (!rows.length) return h("p", "muted", "Henüz veri yok.");
+        rows.forEach((r) => {
+            const row = h("div", "hbar-row");
+            row.appendChild(h("span", "hbar-label", esc(r.label)));
+            const track = h("span", "hbar-track");
+            const pct = max ? Math.max(r.value > 0 ? 2 : 0, (r.value / max) * 100) : 0;
+            const fill = h("span", "hbar-fill");
+            fill.style.width = pct + "%";
+            fill.style.background = col(r.color);
+            track.appendChild(fill);
+            row.appendChild(track);
+            row.appendChild(h("span", "hbar-val", esc(r.value)));
+            wrap.appendChild(row);
+        });
+        return wrap;
+    }
+
+    // stacked bar chart from [{label, parts:[{value,color}]}]
+    function stacked(rows) {
+        const wrap = h("div", "hbar");
+        const totals = rows.map((r) => r.parts.reduce((a, p) => a + p.value, 0));
+        const max = Math.max(0, ...totals);
+        const syms = ["✓", "✗", "∅"];
+        rows.forEach((r, i) => {
+            const total = totals[i];
+            const row = h("div", "hbar-row");
+            row.appendChild(h("span", "hbar-label", esc(r.label)));
+            const track = h("span", "hbar-track");
+            const totalPct = max ? (total / max) * 100 : 0;
+            r.parts.forEach((p) => {
+                if (p.value <= 0) return;
+                const seg = h("span", "hbar-seg");
+                seg.style.width = (total ? (p.value / total) * totalPct : 0) + "%";
+                seg.style.background = col(p.color);
+                track.appendChild(seg);
+            });
+            row.appendChild(track);
+            const detail = r.parts.map((p, j) => p.value
+                ? `<span style="color:${col(p.color)}">${p.value}${syms[j]}</span>` : "")
+                .filter(Boolean).join(" ");
+            row.appendChild(h("span", "hbar-val", `${total} ${detail}`));
+            wrap.appendChild(row);
+        });
+        return wrap;
+    }
+
+    // mini bar sparkline as inline SVG
+    function sparkline(values, token) {
+        const w = 320, ht = 44, n = values.length || 1, max = Math.max(1, ...values);
+        const bw = w / n;
+        const bars = values.map((v, i) => {
+            const bh = (v / max) * (ht - 4);
+            return `<rect x="${(i * bw).toFixed(1)}" y="${(ht - bh).toFixed(1)}" `
+                 + `width="${Math.max(1, bw - 1.5).toFixed(1)}" height="${bh.toFixed(1)}" `
+                 + `rx="1" fill="${col(token)}"></rect>`;
+        }).join("");
+        const svg = h("div", "sparkline");
+        svg.innerHTML = `<svg viewBox="0 0 ${w} ${ht}" preserveAspectRatio="none" width="100%" height="${ht}">${bars}</svg>`;
+        return svg;
+    }
+
+    function rateColor(rate) {
+        return rate >= 80 ? "green" : rate >= 50 ? "yellow" : "red";
+    }
+
+    // ---------------------------------------------------------------- tabs
+    function section(s) {
+        return {
+            genel: genel, krediler: krediler, haftalik: haftalik,
+            kelimeler: kelimeler, gelecek: gelecek,
+        }[activeSub](s);
+    }
+
+    function genel(s) {
+        const frag = document.createDocumentFragment();
+        frag.appendChild(tiles([
+            ["📚 Toplam Kelime", s.total_words, "purple"],
+            ["🚀 Başlanan", s.started_count, "green"],
+            ["🏆 Öğrenilen (21g+)", s.mastered, "yellow"],
+            ["✨ Bugün Yeni", s.new_today, "green"],
+            ["⏰ Tekrar Bekleyen", s.due_now, "red"],
+            ["🔥 Seri (gün)", s.streak, "yellow"],
+            ["💬 Toplam Cevap", s.log_total || s.son10_total, "purple"],
+            ["🎯 Başarı (%)", Math.round(s.overall_rate), "green"],
+            ["💵 Kredi", s.balance, "yellow"],
+        ]));
+        frag.appendChild(panel("📦 Kelime Durumu (SM-2 olgunluk)", "purple", hbar(s.buckets)));
+
+        if (s.hardest && s.hardest.length) {
+            const body = h("div", "text-lines");
+            s.hardest.forEach((e) => {
+                body.appendChild(h("div", null,
+                    `<b>${esc(e.word)}</b> <span style="color:${col(rateColor(e.rate))}">%${Math.round(e.rate)}</span> `
+                    + `<span class="muted">(<span style="color:${col("green")}">${e.correct}✓</span> `
+                    + `<span style="color:${col("red")}">${e.wrong}✗</span> `
+                    + `<span style="color:${col("yellow")}">${e.blank}∅</span>)</span>`));
+            });
+            frag.appendChild(panel("🧗 En Zor 5 Kelime", "red", body));
+        }
+
+        frag.appendChild(panel("♾️ Tüm Zamanlar", "green", allTime(s)));
+        return frag;
+    }
+
+    function allTime(s) {
+        const body = h("div", "text-lines");
+        const lt = s.log_totals || {};
+        if (s.log_total) {
+            body.appendChild(h("div", null,
+                `Toplam cevap: <b>${s.log_total}</b> `
+                + `(<span style="color:${col("green")}">${lt.correct || 0}✓</span> `
+                + `<span style="color:${col("red")}">${lt.wrong || 0}✗</span> `
+                + `<span style="color:${col("yellow")}">${lt.blank || 0}∅</span>)`));
+            body.appendChild(h("div", null,
+                `Genel başarı: <b style="color:${col(rateColor(s.overall_rate))}">%${s.overall_rate}</b>`));
+            body.appendChild(h("div", null, `Çalışılan gün: <b>${s.active_day_count}</b>`));
+            if (s.best_day) body.appendChild(h("div", null,
+                `En yoğun gün: <b>${esc(s.best_day.label)}</b> (${s.best_day.count} cevap)`));
+            body.appendChild(h("div", null, `Aktif gün ortalaması: <b>${s.avg_per_active_day}</b> cevap`));
+            if (s.first_log) body.appendChild(h("div", null, `Kayıt başlangıcı: <b>${esc(s.first_log)}</b>`));
+        } else {
+            body.appendChild(h("div", "muted", "Cevap geçmişi henüz yok — quiz çözdükçe burada birikecek."));
+        }
+        const s10 = s.son10 || {};
+        body.appendChild(h("div", "muted", "&nbsp;"));
+        body.appendChild(h("div", "muted",
+            `Kelime bazlı (son 10 pencere): <span style="color:${col("green")}">${s10.correct || 0}✓</span> `
+            + `<span style="color:${col("red")}">${s10.wrong || 0}✗</span> `
+            + `<span style="color:${col("yellow")}">${s10.blank || 0}∅</span> (toplam ${s.son10_total})`));
+        return body;
+    }
+
+    function krediler(s) {
+        const frag = document.createDocumentFragment();
+        frag.appendChild(tiles([
+            ["💵 Bakiye", s.balance, "yellow"],
+            ["⏱ Alınabilir (dk, bugün)", s.max_today, "green"],
+            ["📺 Bugün Alınan (dk)", s.redeemed_today, "purple"],
+            ["🪙 Bu Hafta Kazanılan", s.earned_week, "green"],
+            ["💸 Bu Hafta Harcanan", s.spent_week, "red"],
+            ["🗓 Sıfırlamaya (gün)", s.days_to_reset == null ? "—" : s.days_to_reset, "red"],
+        ]));
+
+        let p = panel("🪙 Kazanılan Krediler (son 14 gün)", "green", hbar(s.earned_14));
+        p.appendChild(h("p", "muted small",
+            `Her doğru cevap = <b style="color:${col("green")}">${s.credits_per_correct} kredi</b>. `
+            + `Kayıtlı toplam kazanç: <b style="color:${col("green")}">${s.earned_total} kredi</b>`));
+        frag.appendChild(p);
+
+        p = panel("💸 Harcanan Krediler (son 14 gün)", "red", hbar(s.spent_14));
+        p.appendChild(h("p", "muted small",
+            `Alınan dakikalardan hesaplanır. Toplam harcama (son 60 gün): `
+            + `<b style="color:${col("red")}">${s.spent_total} kredi</b>`));
+        frag.appendChild(p);
+
+        p = panel("📺 Alınan Ekran Süresi — günlük (14g) & haftalık (8h)", "yellow", hbar(s.redeemed_14));
+        p.appendChild(hbar(s.redeemed_weekly));
+        p.appendChild(h("p", "muted small",
+            `Bu hafta: <b style="color:${col("yellow")}">${s.minutes_week} dk</b> · `
+            + `Toplam (son 60 gün): <b style="color:${col("yellow")}">${s.redeemed_total} dk</b>`));
+        frag.appendChild(p);
+
+        const price = h("div", "text-lines");
+        s.price_brackets.forEach((b) => {
+            price.appendChild(h("div", null,
+                `${b.hour}. saat: <b>${(+b.rate).toFixed(2).replace(/\.00$/, "")} kredi/dk</b>`
+                + (b.current ? ` <span style="color:${col("yellow")}">◀ şu an</span>` : "")));
+        });
+        price.appendChild(h("div", null,
+            `Şu anki dakika fiyatı: <b style="color:${col("yellow")}">${(+s.current_rate).toFixed(2).replace(/\.00$/, "")} kredi</b> `
+            + `<span class="muted">(bugün ${s.redeemed_today} dk alındı)</span>`));
+        price.appendChild(h("div", null,
+            `Bakiyenle alınabilir: <b style="color:${col("green")}">${s.max_today} dk (bugün)</b> | `
+            + `<b style="color:${col("green")}">${s.max_tomorrow} dk (yarın)</b>`));
+        const mpc = s.base_rate ? (s.credits_per_correct / s.base_rate).toFixed(1) : 0;
+        price.appendChild(h("div", null, `1 doğru cevap ≈ <b>${mpc} dk</b> ekran süresi <span class="muted">(taban fiyattan)</span>`));
+        frag.appendChild(panel("🏷️ Fiyat Tarifesi — her ek saat pahalılaşır", "purple", price));
+
+        frag.appendChild(panel("📉 Ekran süresi — son 30 gün (dk/gün)", "yellow", sparkline(s.spark_minutes_30, "yellow")));
+        return frag;
+    }
+
+    function haftalik(s) {
+        const frag = document.createDocumentFragment();
+        frag.appendChild(panel("🌱 Haftalık Yeni Kelimeler (son 8 hafta)", "green", hbar(s.weekly_new)));
+        frag.appendChild(panel("✨ Günlük Yeni Kelimeler (son 14 gün)", "purple", hbar(s.daily_new)));
+        const legend = h("p", "small", `<span style="color:${col("green")}">█ Doğru</span> `
+            + `<span style="color:${col("red")}">█ Yanlış</span> `
+            + `<span style="color:${col("yellow")}">█ Boş</span>`);
+        const p = panel("💬 Günlük Cevaplar (son 14 gün)", "yellow", legend);
+        p.appendChild(stacked(s.daily_answers));
+        frag.appendChild(p);
+        frag.appendChild(panel("⚡ Aktivite — son 30 gün (günlük cevap)", "green", sparkline(s.spark_30, "green")));
+        frag.appendChild(panel("🌱 Yeni kelime — son 30 gün", "purple", sparkline(s.spark_new_30, "purple")));
+        return frag;
+    }
+
+    function kelimeler(s) {
+        const frag = document.createDocumentFragment();
+        frag.appendChild(panel("🏷️ Kelime Türleri", "purple", hbar(s.word_types)));
+
+        const wrap = h("div", "table-wrap");
+        const table = h("table", "admin-table");
+        table.innerHTML = "<thead><tr><th>Kelime</th><th>Başarı</th><th>✓</th><th>✗</th><th>∅</th>"
+            + "<th>Tekrar</th><th>Aralık</th><th>Sonraki Tekrar</th></tr></thead>";
+        const tb = h("tbody");
+        s.table_rows.forEach((e) => {
+            const tr = h("tr");
+            const rate = e.total
+                ? `<span style="color:${col(rateColor(e.rate))}"><b>%${Math.round(e.rate)}</b></span>`
+                : '<span class="muted">—</span>';
+            const nxt = e.next
+                ? `<span style="color:${e.delta <= 0 ? col("red") : col("muted")}">${esc(e.next)} (${e.delta >= 0 ? "+" : ""}${e.delta}g)</span>`
+                : '<span class="muted">—</span>';
+            tr.innerHTML = `<td class="u-name">${esc(e.word)}</td><td>${rate}</td>`
+                + `<td style="color:${col("green")}">${e.correct}</td>`
+                + `<td style="color:${col("red")}">${e.wrong}</td>`
+                + `<td style="color:${col("yellow")}">${e.blank}</td>`
+                + `<td>${e.repetitions}</td><td>${e.interval}g</td><td>${nxt}</td>`;
+            tb.appendChild(tr);
+        });
+        table.appendChild(tb);
+        wrap.appendChild(table);
+        frag.appendChild(panel(`🔤 Tüm Kelimeler — en zordan kolaya (${s.started_count} başlanan)`, "green", wrap));
+        return frag;
+    }
+
+    function gelecek(s) {
+        const frag = document.createDocumentFragment();
+        frag.appendChild(panel("🔮 Tekrar Takvimi (gelecek 14 gün)", "purple", hbar(s.forecast)));
+        const body = h("div", "text-lines");
+        if (s.sm2) {
+            body.appendChild(h("div", null, `Ortalama kolaylık faktörü (EF): <b>${s.sm2.ef_avg}</b> <span class="muted">(1.30 = en zor, 2.50 = varsayılan)</span>`));
+            body.appendChild(h("div", null, `En düşük EF: <b>${s.sm2.ef_min}</b> · En yüksek EF: <b>${s.sm2.ef_max}</b>`));
+            body.appendChild(h("div", null, `Ortalama tekrar aralığı: <b>${s.sm2.interval_avg} gün</b>`));
+            if (s.sm2.longest_word) body.appendChild(h("div", null,
+                `En uzun aralık: <b>${esc(s.sm2.longest_word)}</b> (<span style="color:${col("green")}">${s.sm2.longest_interval} gün</span>)`));
+        } else {
+            body.appendChild(h("div", "muted", "Henüz çalışılmış kelime yok."));
+        }
+        frag.appendChild(panel("🧠 SM-2 Sağlığı", "green", body));
+        return frag;
+    }
+
+    // ---------------------------------------------------------------- driver
+    function render() {
+        const root = document.getElementById("stats-root");
+        if (!root) return;
+        root.innerHTML = "";
+        if (!payload) { root.appendChild(h("p", "muted", "Yükleniyor…")); return; }
+        root.appendChild(section(payload));
+    }
+
+    async function load() {
+        const root = document.getElementById("stats-root");
+        if (root) root.innerHTML = '<p class="muted">Yükleniyor…</p>';
+        const res = await fetch("/api/stats/full");
+        if (res.status === 401) { window.location.href = "/login"; return; }
+        payload = await res.json();
+        render();
+    }
+
+    function initSubtabs() {
+        document.querySelectorAll("#stats-subtabs .subtab").forEach((b) => {
+            b.addEventListener("click", () => {
+                document.querySelectorAll("#stats-subtabs .subtab").forEach((x) => x.classList.remove("active"));
+                b.classList.add("active");
+                activeSub = b.dataset.sub;
+                render();
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", initSubtabs);
+    window.CoalideStats = { load };
+})();

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -13,6 +13,7 @@
     --yellow: #f4c04d;
     --orange: #f39a5a;
     --red: #ef5f6b;
+    --purple: #8a6cff;
     --shadow: 0 10px 30px rgba(0,0,0,.35);
     --radius: 16px;
 }
@@ -205,17 +206,68 @@ body {
 .redeem-result.ok { color: var(--green); }
 .redeem-result.err { color: var(--red); }
 
-/* ---------- Stats ---------- */
-.stats-grid {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-    gap: 14px; margin-top: 20px;
+/* ---------- Stats dashboard ---------- */
+.stats-heading { margin: 0 0 14px; }
+.stats-subtabs {
+    display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 18px;
+    border-bottom: 1px solid var(--border); padding-bottom: 12px;
 }
-.stat {
-    background: var(--card-2); border: 1px solid var(--border); border-radius: 12px;
-    padding: 18px; text-align: center;
+.subtab {
+    background: transparent; border: 1px solid var(--border); color: var(--muted);
+    padding: 7px 13px; border-radius: 999px; cursor: pointer; font-size: .86rem;
+    transition: background .15s, color .15s, border-color .15s;
 }
-.stat-num { display: block; font-size: 1.9rem; font-weight: 700; color: var(--accent); }
-.stat-label { display: block; color: var(--muted); font-size: .8rem; margin-top: 4px; }
+.subtab:hover { color: var(--text); }
+.subtab.active { color: var(--text); background: var(--card-2); border-color: var(--accent); }
+
+.stat-tiles {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px; margin-bottom: 18px;
+}
+.stat-tile {
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+    padding: 16px; text-align: center; border-top-width: 3px;
+}
+.stat-tile-num { display: block; font-size: 1.8rem; font-weight: 700; line-height: 1.1; }
+.stat-tile-label { display: block; color: var(--muted); font-size: .78rem; margin-top: 5px; }
+.stat-purple { border-top-color: var(--purple); } .stat-purple .stat-tile-num { color: var(--purple); }
+.stat-green  { border-top-color: var(--green); }  .stat-green .stat-tile-num  { color: var(--green); }
+.stat-yellow { border-top-color: var(--yellow); } .stat-yellow .stat-tile-num { color: var(--yellow); }
+.stat-red    { border-top-color: var(--red); }    .stat-red .stat-tile-num    { color: var(--red); }
+
+.stat-panel {
+    background: var(--card); border: 1px solid var(--border); border-left-width: 3px;
+    border-radius: 12px; padding: 18px 20px; margin-bottom: 16px;
+}
+.panel-purple { border-left-color: var(--purple); }
+.panel-green  { border-left-color: var(--green); }
+.panel-yellow { border-left-color: var(--yellow); }
+.panel-red    { border-left-color: var(--red); }
+.stat-panel-title { margin: 0 0 14px; font-size: 1.02rem; }
+.stat-panel .small, p.small { font-size: .82rem; }
+.stat-panel .muted.small, .stat-panel p.muted { margin: 12px 0 0; }
+
+.text-lines > div { padding: 3px 0; font-size: .92rem; }
+
+/* horizontal + stacked bar charts */
+.hbar { display: flex; flex-direction: column; gap: 7px; }
+.hbar-row { display: grid; grid-template-columns: 120px 1fr auto; align-items: center; gap: 10px; font-size: .86rem; }
+.hbar-label { color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hbar-track {
+    height: 16px; background: var(--bg-soft); border-radius: 5px; overflow: hidden;
+    display: flex; min-width: 0;
+}
+.hbar-fill { height: 100%; border-radius: 5px; min-width: 0; transition: width .3s ease; }
+.hbar-seg { height: 100%; }
+.hbar-val { font-weight: 600; font-size: .82rem; white-space: nowrap; }
+
+.sparkline { margin-top: 6px; }
+.sparkline svg { display: block; }
+
+@media (max-width: 560px) {
+    .hbar-row { grid-template-columns: 88px 1fr auto; gap: 7px; font-size: .8rem; }
+    .stat-tiles { grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); }
+}
 
 /* ---------- Admin ---------- */
 .plain-link { color: var(--accent); text-decoration: none; }

--- a/webapp/stats.py
+++ b/webapp/stats.py
@@ -1,0 +1,395 @@
+"""
+Per-user statistics for the web app — a web-safe port of the terminal app's
+``stats_menu.build_stats()`` (and its ``record_answer`` answer log).
+
+The terminal app logs every answer to a single global ``statistics.csv`` and
+derives its rich İstatistikler screen from that log plus ``progress.json`` and
+``<user>_data.json``. This module does the same thing per-user:
+
+    answer log   ->  webapp/data/<user>_stats.csv   (datetime,word,result)
+    progress     ->  webapp/data/<user>_progress.json
+    credits      ->  webapp/data/<user>_data.json
+
+``build_stats(username)`` returns the same set of figures the terminal screen
+shows, JSON-serialised (dates as ISO strings, colours as semantic tokens the
+front end maps to CSS), so the web dashboard can render all five terminal tabs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from datetime import date, datetime, timedelta
+
+import engine
+
+STATS_SUFFIX = "_stats.csv"
+
+MATURE_INTERVAL = 21  # days; an SM-2 interval this long counts as "learned/mastered"
+MINUTES_PER_DAY = 24 * 60
+
+# Colour tokens (the front end maps these to CSS variables).
+M, R, Y, P, G = "muted", "red", "yellow", "purple", "green"
+
+TR_MONTHS = ["Oca", "Şub", "Mar", "Nis", "May", "Haz",
+             "Tem", "Ağu", "Eyl", "Eki", "Kas", "Ara"]
+
+
+# --------------------------------------------------------------------------- #
+# Answer log (<user>_stats.csv)                                                #
+# --------------------------------------------------------------------------- #
+
+def _log_path(username: str) -> str:
+    return os.path.join(engine.DATA_DIR, f"{engine._safe_username(username)}{STATS_SUFFIX}")
+
+
+def record_answer(username: str, word: str, result) -> None:
+    """
+    Append one answered question to the user's stats log. ``result`` is
+    True (correct) / False (wrong) / None (blank). Never raises — a logging
+    failure must not break the quiz.
+    """
+    try:
+        res = "correct" if result is True else "wrong" if result is False else "blank"
+        path = _log_path(username)
+        is_new = not os.path.exists(path)
+        with open(path, "a", encoding="utf-8") as f:
+            if is_new:
+                f.write("datetime,word,result\n")
+            f.write(f"{datetime.now().isoformat(timespec='seconds')},{word},{res}\n")
+    except Exception:
+        pass
+
+
+def load_log(username: str) -> list:
+    """Read <user>_stats.csv -> list of (date, word, result) tuples."""
+    rows = []
+    path = _log_path(username)
+    if not os.path.exists(path):
+        return rows
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                parts = line.strip().split(",")
+                if len(parts) < 3 or parts[0].startswith("datetime"):
+                    continue
+                d = _parse_date(parts[0][:10])
+                if d is None:
+                    continue
+                rows.append((d, parts[1], parts[2]))
+    except Exception:
+        pass
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+def _parse_date(s):
+    try:
+        return date.fromisoformat(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _week_start(d: date) -> date:
+    return d - timedelta(days=d.weekday())
+
+
+def _day_label(d: date) -> str:
+    return f"{d.day} {TR_MONTHS[d.month - 1]}"
+
+
+def _iso(d):
+    return d.isoformat() if d else None
+
+
+def _cost_for_minutes(minutes: int, base: float, esc: float, already: int = 0) -> int:
+    total = 0.0
+    for m in range(minutes):
+        total += base * (1 + esc * ((already + m) // 60))
+    return round(total)
+
+
+def _max_redeemable(balance: int, base: float, esc: float, already: int = 0) -> int:
+    minutes = 0
+    total = 0.0
+    while already + minutes < MINUTES_PER_DAY:
+        rate = base * (1 + esc * ((already + minutes) // 60))
+        if round(total + rate) > balance:
+            break
+        total += rate
+        minutes += 1
+    return minutes
+
+
+# --------------------------------------------------------------------------- #
+# build_stats                                                                  #
+# --------------------------------------------------------------------------- #
+
+def build_stats(username: str) -> dict:
+    today = date.today()
+    progress = engine.load_progress(username)
+    words = engine._read_json_list(engine.WORDS_FILE)
+    log = load_log(username)
+    cfg = engine.get_config(username)
+    from credits import load_user
+    user = load_user(username)
+
+    credits_per_correct = cfg.get("CREDITS_PER_CORRECT", 7)
+    base_rate = cfg.get("BASE_RATE_PER_MINUTE", 5)
+    escalation = cfg.get("ESCALATION_PER_HOUR", 0.5)
+    weekly_reset = cfg.get("Credit_Reset_Weekly", True)
+
+    # ---- per-word state ----
+    started = []
+    for target, p in progress.items():
+        if not isinstance(p, dict):
+            continue
+        attempts = p.get("last_ten_attempts") or []
+        total = len(attempts) or p.get("total_attempts", 0)
+        correct = p.get("correct_attempts", 0)
+        wrong = p.get("wrong_attempts", 0)
+        blank = p.get("blank_attempts", 0)
+        started.append({
+            "word": target,
+            "rate": (correct / total * 100) if total else 0.0,
+            "total": total, "correct": correct, "wrong": wrong, "blank": blank,
+            "repetitions": p.get("repetitions", 0),
+            "ease": p.get("ease_factor", 2.5),
+            "interval": p.get("interval", 0),
+            "first": _parse_date(p.get("first_review_date")),
+            "last": _parse_date(p.get("last_review_date")),
+            "next": _parse_date(p.get("next_review_date")),
+        })
+
+    total_words = len(words)
+    started_count = len(started)
+    not_started = max(0, total_words - started_count)
+    mastered = sum(1 for e in started if e["interval"] >= MATURE_INTERVAL)
+
+    # ---- maturity buckets ----
+    buckets = [
+        {"label": "Başlanmadı", "value": not_started, "color": M},
+        {"label": "Yeni (≤1 gün)", "value": sum(1 for e in started if e["interval"] <= 1), "color": R},
+        {"label": "Öğreniliyor (2-6g)", "value": sum(1 for e in started if 2 <= e["interval"] <= 6), "color": Y},
+        {"label": "Genç (1-3 hafta)", "value": sum(1 for e in started if 7 <= e["interval"] < MATURE_INTERVAL), "color": P},
+        {"label": "Olgun (3h-2 ay)", "value": sum(1 for e in started if MATURE_INTERVAL <= e["interval"] < 60), "color": G},
+        {"label": "Usta (2 ay+)", "value": sum(1 for e in started if e["interval"] >= 60), "color": G},
+    ]
+
+    # ---- new words per day / week ----
+    new_dates = [e["first"] for e in started if e["first"]]
+    new_by_day = Counter(new_dates)
+    new_today = new_by_day.get(today, 0)
+    ws0 = _week_start(today)
+
+    weekly_new = []
+    for i in range(7, -1, -1):
+        ws = ws0 - timedelta(weeks=i)
+        cnt = sum(1 for d in new_dates if ws <= d < ws + timedelta(days=7))
+        label = f"{_day_label(ws)} +" if ws != ws0 else "Bu hafta"
+        weekly_new.append({"label": label, "value": cnt, "color": G if cnt else M})
+
+    daily_new = []
+    for i in range(13, -1, -1):
+        d = today - timedelta(days=i)
+        cnt = new_by_day.get(d, 0)
+        daily_new.append({"label": _day_label(d), "value": cnt, "color": P if cnt else M})
+
+    # ---- answers from the log ----
+    answers_by_day = {}
+    for d, _w, res in log:
+        answers_by_day.setdefault(d, Counter())[res] += 1
+    log_totals = Counter(res for _d, _w, res in log)
+
+    daily_answers = []
+    for i in range(13, -1, -1):
+        d = today - timedelta(days=i)
+        c = answers_by_day.get(d, Counter())
+        daily_answers.append({"label": _day_label(d), "parts": [
+            {"value": c.get("correct", 0), "color": G},
+            {"value": c.get("wrong", 0), "color": R},
+            {"value": c.get("blank", 0), "color": Y},
+        ]})
+
+    spark_30 = [sum(answers_by_day.get(today - timedelta(days=i), Counter()).values())
+                for i in range(29, -1, -1)]
+    spark_new_30 = [new_by_day.get(today - timedelta(days=i), 0) for i in range(29, -1, -1)]
+
+    # ---- streak ----
+    active_days = set(answers_by_day)
+    for e in started:
+        for k in ("first", "last"):
+            if e[k]:
+                active_days.add(e[k])
+    streak = 0
+    d = today if today in active_days else today - timedelta(days=1)
+    while d in active_days:
+        streak += 1
+        d -= timedelta(days=1)
+
+    # ---- all-time ----
+    log_total = sum(log_totals.values())
+    son10 = Counter()
+    for e in started:
+        son10["correct"] += e["correct"]
+        son10["wrong"] += e["wrong"]
+        son10["blank"] += e["blank"]
+    son10_total = sum(son10.values())
+
+    if log_total:
+        overall_rate = log_totals.get("correct", 0) / log_total * 100
+    elif son10_total:
+        overall_rate = son10["correct"] / son10_total * 100
+    else:
+        overall_rate = 0.0
+
+    best_day = max(answers_by_day.items(), key=lambda kv: sum(kv[1].values()), default=None)
+    first_log = min((d for d, _w, _r in log), default=None)
+
+    # ---- review forecast ----
+    overdue = sum(1 for e in started if e["next"] and e["next"] < today)
+    forecast = [{"label": "Gecikmiş", "value": overdue, "color": R}]
+    for i in range(14):
+        d = today + timedelta(days=i)
+        cnt = sum(1 for e in started if e["next"] == d)
+        label = "Bugün" if i == 0 else "Yarın" if i == 1 else _day_label(d)
+        forecast.append({"label": label, "value": cnt, "color": Y if i == 0 else (P if cnt else M)})
+
+    # ---- SM-2 health ----
+    eases = [e["ease"] for e in started]
+    intervals = [e["interval"] for e in started]
+    longest = max(started, key=lambda e: e["interval"], default=None)
+    sm2 = None
+    if eases:
+        sm2 = {
+            "ef_avg": round(sum(eases) / len(eases), 2),
+            "ef_min": round(min(eases), 2),
+            "ef_max": round(max(eases), 2),
+            "interval_avg": round(sum(intervals) / len(intervals)),
+            "longest_word": longest["word"] if longest else None,
+            "longest_interval": longest["interval"] if longest else 0,
+        }
+
+    # ---- hardest words / table ----
+    attempted = [e for e in started if e["total"] > 0]
+    hardest = sorted(attempted, key=lambda e: (e["rate"], -e["wrong"]))[:5]
+    table_rows = sorted(started, key=lambda e: (e["rate"], -e["wrong"]))
+
+    def _word_row(e):
+        return {
+            "word": e["word"], "rate": round(e["rate"], 1), "total": e["total"],
+            "correct": e["correct"], "wrong": e["wrong"], "blank": e["blank"],
+            "repetitions": e["repetitions"], "interval": e["interval"],
+            "next": _iso(e["next"]),
+            "delta": (e["next"] - today).days if e["next"] else None,
+        }
+
+    # ---- word types ----
+    word_types_ctr = Counter((w.get("word_type") or "?").strip().lower() or "?"
+                             for w in words if isinstance(w, dict))
+    word_types = [{"label": t, "value": c, "color": P} for t, c in word_types_ctr.most_common()]
+
+    # ---- screen time / credits ----
+    balance = user.get("balance") if isinstance(user.get("balance"), (int, float)) else 0
+    redeemed = {}
+    for k, v in (user.get("redeemed_minutes_by_date") or {}).items():
+        pd = _parse_date(k)
+        if pd and isinstance(v, (int, float)):
+            redeemed[pd] = v
+
+    redeemed_14 = []
+    for i in range(13, -1, -1):
+        d = today - timedelta(days=i)
+        m = redeemed.get(d, 0)
+        redeemed_14.append({"label": _day_label(d), "value": m, "color": Y if m else M})
+
+    redeemed_weekly = []
+    for i in range(7, -1, -1):
+        ws = ws0 - timedelta(weeks=i)
+        m = sum(v for d, v in redeemed.items() if ws <= d < ws + timedelta(days=7))
+        label = f"{_day_label(ws)} +" if ws != ws0 else "Bu hafta"
+        redeemed_weekly.append({"label": label, "value": m, "color": G if m else M})
+
+    spent_by_day = {d: _cost_for_minutes(int(m), base_rate, escalation) for d, m in redeemed.items()}
+    spent_14 = []
+    for i in range(13, -1, -1):
+        d = today - timedelta(days=i)
+        c = spent_by_day.get(d, 0)
+        spent_14.append({"label": _day_label(d), "value": c, "color": R if c else M})
+
+    earned_by_day = {d: c.get("correct", 0) * credits_per_correct for d, c in answers_by_day.items()}
+    earned_14 = []
+    for i in range(13, -1, -1):
+        d = today - timedelta(days=i)
+        c = earned_by_day.get(d, 0)
+        earned_14.append({"label": _day_label(d), "value": c, "color": G if c else M})
+
+    earned_week = sum(v for d, v in earned_by_day.items() if d >= ws0)
+    spent_week = sum(v for d, v in spent_by_day.items() if d >= ws0)
+    minutes_week = sum(v for d, v in redeemed.items() if d >= ws0)
+
+    redeemed_today = int(redeemed.get(today, 0))
+    redeemed_tomorrow = int(redeemed.get(today + timedelta(days=1), 0))
+    max_today = _max_redeemable(balance, base_rate, escalation, redeemed_today)
+    max_tomorrow = _max_redeemable(balance, base_rate, escalation, redeemed_tomorrow)
+    current_rate = base_rate * (1 + escalation * (redeemed_today // 60))
+    price_brackets = [{"hour": h + 1, "rate": base_rate * (1 + escalation * h),
+                       "current": h == redeemed_today // 60} for h in range(4)]
+    days_to_reset = (7 - today.weekday()) if weekly_reset else None
+    spark_minutes_30 = [redeemed.get(today - timedelta(days=i), 0) for i in range(29, -1, -1)]
+
+    return {
+        "today": _iso(today),
+        "total_words": total_words,
+        "started_count": started_count,
+        "mastered": mastered,
+        "new_today": new_today,
+        "due_now": overdue + sum(1 for e in started if e["next"] == today),
+        "streak": streak,
+        "buckets": buckets,
+        "weekly_new": weekly_new,
+        "daily_new": daily_new,
+        "daily_answers": daily_answers,
+        "spark_30": spark_30,
+        "spark_new_30": spark_new_30,
+        "log_totals": dict(log_totals),
+        "log_total": log_total,
+        "son10": dict(son10),
+        "son10_total": son10_total,
+        "overall_rate": round(overall_rate, 1),
+        "best_day": {"label": _day_label(best_day[0]), "count": sum(best_day[1].values())} if best_day else None,
+        "first_log": _iso(first_log),
+        "active_day_count": len(answers_by_day),
+        "avg_per_active_day": round(log_total / len(answers_by_day), 1) if answers_by_day else 0,
+        "forecast": forecast,
+        "sm2": sm2,
+        "hardest": [_word_row(e) for e in hardest],
+        "table_rows": [_word_row(e) for e in table_rows],
+        "word_types": word_types,
+        "credits_per_correct": credits_per_correct,
+        "balance": balance,
+        "redeemed_14": redeemed_14,
+        "redeemed_total": sum(redeemed.values()),
+        "redeemed_weekly": redeemed_weekly,
+        "spent_14": spent_14,
+        "spent_total": sum(spent_by_day.values()),
+        "earned_14": earned_14,
+        "earned_total": sum(earned_by_day.values()),
+        "earned_week": earned_week,
+        "spent_week": spent_week,
+        "minutes_week": minutes_week,
+        "redeemed_today": redeemed_today,
+        "redeemed_tomorrow": redeemed_tomorrow,
+        "max_today": max_today,
+        "max_tomorrow": max_tomorrow,
+        "current_rate": current_rate,
+        "price_brackets": price_brackets,
+        "base_rate": base_rate,
+        "escalation": escalation,
+        "days_to_reset": days_to_reset,
+        "spark_minutes_30": spark_minutes_30,
+    }

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -90,17 +90,15 @@
 
         <!-- STATS VIEW -->
         <section id="view-stats" class="view">
-            <div class="card">
-                <h2 class="view-title">📊 İstatistiklerin</h2>
-                <div class="stats-grid" id="stats-grid">
-                    <div class="stat"><span class="stat-num" id="s-seen">–</span><span class="stat-label">Görülen kelime</span></div>
-                    <div class="stat"><span class="stat-num" id="s-total">–</span><span class="stat-label">Toplam kelime</span></div>
-                    <div class="stat"><span class="stat-num" id="s-due">–</span><span class="stat-label">Şimdi tekrar</span></div>
-                    <div class="stat"><span class="stat-num" id="s-mastered">–</span><span class="stat-label">İyi bilinen</span></div>
-                    <div class="stat"><span class="stat-num" id="s-rate">–</span><span class="stat-label">Başarı oranı</span></div>
-                    <div class="stat"><span class="stat-num" id="s-balance">–</span><span class="stat-label">Kredi</span></div>
-                </div>
+            <h2 class="view-title stats-heading">📊 İstatistiklerin</h2>
+            <div class="stats-subtabs" id="stats-subtabs">
+                <button class="subtab active" data-sub="genel">📊 Genel Bakış</button>
+                <button class="subtab" data-sub="krediler">💰 Krediler</button>
+                <button class="subtab" data-sub="haftalik">📅 Haftalık &amp; Günlük</button>
+                <button class="subtab" data-sub="kelimeler">🔤 Kelimeler</button>
+                <button class="subtab" data-sub="gelecek">🔮 Gelecek &amp; SM-2</button>
             </div>
+            <div id="stats-root"><p class="muted">Yükleniyor…</p></div>
         </section>
     </main>
 
@@ -110,6 +108,7 @@
             targetLanguage: {{ target_language|tojson }}
         };
     </script>
+    <script src="{{ url_for('static', filename='stats.js') }}"></script>
     <script src="{{ url_for('static', filename='app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to the web app (PRs #56 and #57, already merged). Two new, self-contained additions under `webapp/`.

## 1. Terminal-user importer (`webapp/import_user.py`)
Brings a learner's existing terminal-app files into the web app instead of renaming by hand:

```bash
cd webapp
python import_user.py <username> <folder> [--config] [--force]
```

- `progress.json` → `data/<user>_progress.json`
- `*_data.json` / `data.json` → `data/<user>_data.json` — **and rewrites the internal `"username"` field** to match the filename (a plain rename leaves it stale, which would make the app later save to the wrong file)
- `statistics.csv` → `data/<user>_stats.csv`
- `config.json` (with `--config`) → `data/<user>_config.json`, pruned to just the keys that differ from the shared root config
- `version.json` / `words.json` → ignored (unused by the web app)

## 2. Full per-user statistics
The web app now logs every answer and shows the same İstatistikler screen as the terminal app, per user.

**Backend**
- `webapp/stats.py`: per-user answer log at `data/<user>_stats.csv` (same `datetime,word,result` format as the terminal) plus a web-safe port of `stats_menu.build_stats` — SM-2 maturity buckets, new-words/answers by day and week, 30-day sparklines, streak, all-time totals, review forecast, SM-2 health, hardest words, per-word table, and the full credit earn/spend/redeem breakdown. All per-user and JSON-serialisable.
- `api_answer` logs each graded answer; new `GET /api/stats/full` returns the dashboard payload (the lightweight `/api/stats` stays for the header pill).

**Frontend**
- `webapp/static/stats.js` renders the dashboard with five sub-tabs mirroring the terminal (Genel Bakış / Krediler / Haftalık & Günlük / Kelimeler / Gelecek & SM-2), using self-contained bar, stacked-bar and SVG sparkline charts plus the per-word table.
- Stats tab in `index.html` rebuilt around the sub-tabs; styling added.

## Notes
- New per-user files (`data/*.csv`) are gitignored alongside the existing `data/*.json`.
- README updated for both features (importer usage, stats mapping, project layout).
- Verified end-to-end against a real imported user (1,402-answer history): import, `build_stats`, and all five dashboard tabs render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0117Qg1DmpxWfzUk88TPYnGe)_