### PR TITLE
Add a per-day answer log, a time window for Genel Başarı, and home links on the logos

### DIFF
--- a/new_master.py
+++ b/new_master.py
@@ -16,7 +16,7 @@ from utils import lg,get_config,repair_config,get_current_user,cls
 try:
     from stats_menu import record_answer
 except Exception:
-    def record_answer(word, result): pass  # stats logging must never block the quiz
+    def record_answer(word, result, **kw): pass  # stats logging must never block the quiz
 
 
 # Public Modules
@@ -267,7 +267,11 @@ def quest(user, current_question: Question = None):
                 window_start = cfg.get("Credit_Window_Start", "07:00")
                 window_end = cfg.get("Credit_Window_End", "22:00")
                 print(Fore.YELLOW + f"Doğru cevap için kredi kazanılmadı: kredi kazanma saatleri {window_start}-{window_end} arası." + Style.RESET_ALL)
-        record_answer(current_question.word.target, stat)
+        record_answer(current_question.word.target, stat,
+                      given=answer,
+                      expected=current_question.expected_answer,
+                      prompt=current_question.prompt,
+                      direction="target" if current_question.is_target_wanted else "source")
         current_question.word.add_result((True if stat == True else False), is_blank=(stat is None))
         update_sm2(current_question.word, quality)
         feed.append(current_question.word.id)

--- a/serverside/admin.html
+++ b/serverside/admin.html
@@ -19,7 +19,10 @@
     font-size:14px;line-height:1.45;min-height:100vh;-webkit-font-smoothing:antialiased;}
   header{position:sticky;top:0;z-index:20;background:rgba(13,13,24,.85);backdrop-filter:blur(10px);
     border-bottom:1px solid var(--border);padding:12px 24px;display:flex;align-items:center;gap:16px;flex-wrap:wrap;}
-  .brand{display:flex;align-items:center;gap:11px;}
+  .brand{display:flex;align-items:center;gap:11px;color:inherit;text-decoration:none;
+    border-radius:10px;padding:2px 4px;margin:-2px -4px;transition:background .15s;}
+  .brand:hover{background:rgba(124,92,255,.12);}
+  .brand:focus-visible{outline:2px solid var(--purple);outline-offset:2px;}
   .logo{width:34px;height:34px;border-radius:9px;background:linear-gradient(135deg,var(--purple),#b79bff);
     display:grid;place-items:center;font-size:18px;box-shadow:0 4px 14px rgba(124,92,255,.4);}
   .brand .t{font-size:16px;font-weight:700;} .brand .s{font-size:11px;color:var(--muted);margin-top:-2px;}
@@ -98,7 +101,7 @@
 </head>
 <body>
 <header>
-  <div class="brand"><div class="logo">🛠️</div><div><div class="t">COALIDE</div><div class="s">Yönetim Paneli</div></div></div>
+  <a class="brand" href="/" title="Veli paneline dön"><div class="logo">🛠️</div><div><div class="t">COALIDE</div><div class="s">Yönetim Paneli</div></div></a>
   <div class="spacer"></div>
   <a class="link" href="/">← Panele dön</a>
   <button id="logout" style="display:none">🚪 Çıkış</button>

--- a/serverside/dashboard.html
+++ b/serverside/dashboard.html
@@ -231,13 +231,16 @@
   .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-weight: 700; font-size: 12px; }
 
   /* answer-log day picker */
-  .daybar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-  .daybar input[type="date"] {
+  .daybar, .rangebar { display: flex; align-items: center; gap: 8px 10px; flex-wrap: wrap; }
+  /* label + input stay together when the row wraps */
+  .rangebar .fld { display: flex; align-items: center; gap: 8px; }
+  .rangebar .lbl { font-size: 11.5px; color: var(--muted); }
+  .daybar input[type="date"], .rangebar input[type="date"] {
     background: var(--surface); color: var(--ink); border: 1px solid var(--border);
     border-radius: 9px; padding: 8px 12px; font: inherit; font-size: 13px;
     min-height: var(--tap); color-scheme: dark; cursor: pointer;
   }
-  .daybar input[type="date"]:hover { border-color: var(--purple); }
+  .daybar input[type="date"]:hover, .rangebar input[type="date"]:hover { border-color: var(--purple); }
   .daybar .nav { padding: 8px 13px; font-size: 15px; line-height: 1; }
   .daybar .hint { font-size: 11.5px; color: var(--muted); margin-left: auto; }
   .chips { display: flex; gap: 6px; flex-wrap: wrap; }
@@ -372,6 +375,12 @@ function niceScale(m, maxTicks = 6) {
   return { ymax: m, ticks: 4 };
 }
 function dayLabel(d) { return `${d.getDate()} ${TR_MONTHS[d.getMonth()]}`; }
+// Format a Date as YYYY-MM-DD in local time. toISOString() would convert to
+// UTC first and land on the wrong day for anyone east or west of it.
+function isoOf(d) { return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`; }
+function parseISO(s) { return new Date(s + "T00:00:00"); }
+function shiftISO(s, days) { const d = parseISO(s); d.setDate(d.getDate() + days); return isoOf(d); }
+function longDate(s) { const d = parseISO(s); return `${d.getDate()} ${TR_MONTHS[d.getMonth()]} ${d.getFullYear()}`; }
 function backLabels(todayStr, n) { const out = []; const t = new Date(todayStr + "T00:00:00"); for (let i = n - 1; i >= 0; i--) { const d = new Date(t); d.setDate(t.getDate() - i); out.push(dayLabel(d)); } return out; }
 
 // ---------- tooltip ----------
@@ -414,7 +423,7 @@ function card(title, sub, cls) {
   const act = el("div", "hact"); h.appendChild(act);
   c.appendChild(h);
   const b = el("div", "body"); c.appendChild(b);
-  c._body = b; c._act = act; return c;
+  c._body = b; c._act = act; c._ht = ht; return c;
 }
 // items: [color, name, isLine?, mark?] — `mark` is the non-colour cue that
 // keeps a series identifiable without relying on hue alone.
@@ -742,25 +751,116 @@ function plot(c, build, table) {
 }
 const seriesRows = (labels, series) => labels.map((l, i) => [l, ...series.map(se => fmtNum(num(se.values[i])))]);
 
+// Genel Başarı — all time by default, with preset and custom windows summed
+// from the per-day breakdown the client ships.
+const RANGE_PRESETS = [["all", "Tüm zamanlar"], ["today", "Bugün"], ["yesterday", "Dün"],
+                       ["week", "Bu hafta"], ["month", "Bu ay"], ["custom", "Özel"]];
+let _range = { key: "all", from: null, to: null };
+function rangeBounds(key, today) {
+  const t = parseISO(today);
+  switch (key) {
+    case "today": return [today, today];
+    case "yesterday": { const y = shiftISO(today, -1); return [y, y]; }
+    // weeks start Monday, matching the client's own week bucketing
+    case "week": return [shiftISO(today, -((t.getDay() + 6) % 7)), today];
+    case "month": return [`${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, "0")}-01`, today];
+    default: return [null, null];
+  }
+}
+function successCard(st) {
+  const lt = st.log_totals || {};
+  const byDate = st.answers_by_date;
+  const c = card("Genel Başarı", "");
+  const today = st.today;
+
+  // Older clients don't send the per-day breakdown — show all-time only.
+  if (!byDate || typeof byDate !== "object") {
+    c._ht.appendChild(txt("div", "sub", "tüm kayıtlı cevaplara göre"));
+    c._body.appendChild(successBody(st, {
+      correct: num(lt.correct), wrong: num(lt.wrong), blank: num(lt.blank),
+    }, num(st.overall_rate)));
+    return c;
+  }
+
+  const sub = txt("div", "sub", "");
+  c._ht.appendChild(sub);
+
+  const chips = el("div", "chips");
+  const custom = el("div", "rangebar");
+  custom.style.display = "none";
+  const from = document.createElement("input"), to = document.createElement("input");
+  from.type = to.type = "date";
+  const dates = Object.keys(byDate).sort();
+  if (dates.length) { from.min = to.min = dates[0]; from.max = to.max = today; }
+  _range.from = _range.from || dates[0] || today;
+  _range.to = _range.to || today;
+  from.value = _range.from; to.value = _range.to;
+  const field = (label, input) => { const f = el("div", "fld"); f.append(txt("span", "lbl", label), input); return f; };
+  custom.append(field("Başlangıç", from), field("Bitiş", to));
+
+  const body = el("div");
+  c._body.append(chips, custom, body);
+
+  const chipEls = RANGE_PRESETS.map(([key, label]) => {
+    const b = txt("button", "chip", label);
+    b.setAttribute("aria-pressed", String(key === _range.key));
+    b.onclick = () => {
+      _range.key = key;
+      chipEls.forEach((e, i) => e.setAttribute("aria-pressed", String(RANGE_PRESETS[i][0] === key)));
+      render();
+    };
+    chips.appendChild(b);
+    return b;
+  });
+  from.onchange = to.onchange = () => {
+    if (from.value && to.value && from.value > to.value) { const v = from.value; from.value = to.value; to.value = v; }
+    _range.from = from.value; _range.to = to.value;
+    render();
+  };
+
+  function render() {
+    custom.style.display = _range.key === "custom" ? "" : "none";
+    const [lo, hi] = _range.key === "custom" ? [_range.from, _range.to] : rangeBounds(_range.key, today);
+    let correct = 0, wrong = 0, blank = 0;
+    for (const d in byDate) {
+      if ((lo && d < lo) || (hi && d > hi)) continue;
+      const v = byDate[d] || [];
+      correct += num(v[0]); wrong += num(v[1]); blank += num(v[2]);
+    }
+    const total = correct + wrong + blank;
+    // All time falls back to the client's own figure, which also covers the
+    // pre-log answers folded into overall_rate.
+    const rate = _range.key === "all" && !total ? num(st.overall_rate)
+               : total ? correct / total * 100 : 0;
+    sub.textContent = _range.key === "all" ? "tüm kayıtlı cevaplara göre"
+      : (lo === hi ? longDate(lo) : `${longDate(lo)} – ${longDate(hi)}`);
+    body.replaceChildren(successBody(st, { correct, wrong, blank }, rate, total === 0));
+  }
+  render();
+  return c;
+}
+function successBody(st, counts, rate, empty) {
+  const ring = el("div", "ringwrap");
+  const rw = el("div", "ring");
+  rw.appendChild(progressRing({ value: rate, color: empty ? C.muted : rateColor(rate), label: "başarı oranı" }));
+  ring.appendChild(rw);
+  const meta = el("div", "meta");
+  meta.appendChild(kpiRow([
+    { label: "Doğru ✓", value: counts.correct, color: C.green },
+    { label: "Yanlış ✗", value: counts.wrong, color: C.red },
+    { label: "Boş ∅", value: counts.blank, color: C.yellow },
+    { label: "Toplam", value: counts.correct + counts.wrong + counts.blank, color: C.purple },
+  ], "pair"));
+  if (empty) meta.appendChild(txt("p", "note", "Bu aralıkta kayıtlı cevap yok."));
+  ring.appendChild(meta);
+  return ring;
+}
+
 function pageGenel(st) {
   const root = el("div", "grid");
   const lt = st.log_totals || {};
 
-  const heroCard = card("Genel Başarı", "tüm kayıtlı cevaplara göre");
-  const ring = el("div", "ringwrap");
-  const rw = el("div", "ring");
-  rw.appendChild(progressRing({ value: num(st.overall_rate), color: rateColor(num(st.overall_rate)), label: "başarı oranı" }));
-  ring.appendChild(rw);
-  const meta = el("div", "meta");
-  meta.appendChild(kpiRow([
-    { label: "Doğru ✓", value: num(lt.correct), color: C.green },
-    { label: "Yanlış ✗", value: num(lt.wrong), color: C.red },
-    { label: "Boş ∅", value: num(lt.blank), color: C.yellow },
-    { label: "Seri", value: num(st.streak), unit: "gün", color: C.purple },
-  ], "pair"));
-  ring.appendChild(meta);
-  heroCard._body.appendChild(ring);
-  root.appendChild(gcol(5, heroCard));
+  root.appendChild(gcol(6, successCard(st)));
 
   const kpiCard = card("Özet", "");
   kpiCard._body.appendChild(kpiRow([
@@ -769,9 +869,10 @@ function pageGenel(st) {
     { label: `Öğrenilen (${MATURE}g+)`, value: st.mastered, color: C.yellow },
     { label: "Bugün yeni", value: st.new_today, color: C.green },
     { label: "Tekrar bekleyen", value: st.due_now, color: C.red },
+    { label: "Seri", value: st.streak, unit: "gün", color: C.purple },
     { label: "Kredi", value: st.balance, color: C.yellow },
   ]));
-  root.appendChild(gcol(7, kpiCard));
+  root.appendChild(gcol(6, kpiCard));
 
   // Maturity distribution — ordered buckets, so a single-hue ordinal ramp.
   const bucketList = st.buckets || [];
@@ -1020,7 +1121,7 @@ function answerLogCard(st) {
   }
 
   function goto(d) { day = d; input.value = d; render(); }
-  const shift = n => { const t = new Date(day + "T00:00:00"); t.setDate(t.getDate() + n); goto(t.toISOString().slice(0, 10)); };
+  const shift = n => goto(shiftISO(day, n));
   prev.onclick = () => shift(-1);
   next.onclick = () => shift(1);
   todayBtn.onclick = () => goto(today);

--- a/serverside/dashboard.html
+++ b/serverside/dashboard.html
@@ -61,7 +61,13 @@
     padding: 10px max(14px, env(safe-area-inset-left)) 10px max(14px, env(safe-area-inset-right));
     display: flex; align-items: center; gap: 10px 14px; flex-wrap: wrap;
   }
-  .brand { display: flex; align-items: center; gap: 11px; min-width: 0; }
+  .brand {
+    display: flex; align-items: center; gap: 11px; min-width: 0;
+    color: inherit; text-decoration: none; border-radius: 10px;
+    padding: 2px 4px; margin: -2px -4px; transition: background .15s;
+  }
+  .brand:hover { background: rgba(124,92,255,.12); }
+  .brand:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
   .logo {
     width: 34px; height: 34px; border-radius: 9px; flex: none;
     background: linear-gradient(135deg, var(--purple), #b79bff);
@@ -224,6 +230,36 @@
   td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
   .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-weight: 700; font-size: 12px; }
 
+  /* answer-log day picker */
+  .daybar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .daybar input[type="date"] {
+    background: var(--surface); color: var(--ink); border: 1px solid var(--border);
+    border-radius: 9px; padding: 8px 12px; font: inherit; font-size: 13px;
+    min-height: var(--tap); color-scheme: dark; cursor: pointer;
+  }
+  .daybar input[type="date"]:hover { border-color: var(--purple); }
+  .daybar .nav { padding: 8px 13px; font-size: 15px; line-height: 1; }
+  .daybar .hint { font-size: 11.5px; color: var(--muted); margin-left: auto; }
+  .chips { display: flex; gap: 6px; flex-wrap: wrap; }
+  .chip {
+    padding: 5px 11px; border-radius: 999px; border: 1px solid var(--border);
+    background: var(--surface); color: var(--ink2); font-size: 12px; font-weight: 600;
+    cursor: pointer; min-height: 30px;
+  }
+  .chip:hover { border-color: var(--purple); color: var(--ink); }
+  .chip[aria-pressed="true"] { background: rgba(124,92,255,.20); border-color: var(--purple); color: var(--ink); }
+  td.wrap, th.wrap { white-space: normal; min-width: 110px; overflow-wrap: anywhere; }
+  /* On a phone the time gets its own line under the question, so the columns
+     that matter — what was asked and what the child answered — fit on screen. */
+  .t-sm { display: none; }
+  @media (max-width: 640px) {
+    .c-time { display: none; }
+    .t-sm { display: block; font-size: 11px; font-weight: 400; color: var(--muted); font-variant-numeric: tabular-nums; }
+  }
+  .badge { display: inline-flex; align-items: center; gap: 5px; padding: 2px 9px; border-radius: 999px; font-size: 12px; font-weight: 700; background: rgba(255,255,255,.05); white-space: nowrap; }
+  .given-wrong { color: var(--red); }
+  .given-empty { color: var(--muted); font-style: italic; }
+
   /* meter (price tariff) */
   .meter { margin: 10px 0; padding-left: 10px; border-left: 2px solid transparent; }
   .meter.now { border-left-color: var(--yellow); }
@@ -267,10 +303,10 @@
 </head>
 <body data-palette="#41dca5,#f9667a,#f5c542" data-mode="dark">
 <header>
-  <div class="brand">
+  <a class="brand" href="/" title="Ana sayfaya dön">
     <div class="logo">🌍</div>
     <div><div class="t">COALIDE</div><div class="s">Veli Paneli</div></div>
-  </div>
+  </a>
   <div class="spacer"></div>
   <div class="ctl">
     <label for="user">Öğrenci</label>
@@ -861,8 +897,142 @@ function pageKredi(st) {
   return root;
 }
 
+// Per-day answer log: pick a date, see every question asked that day, what the
+// child typed and how it was graded. Defaults to today.
+const RESULT_META = {
+  correct: { mark: "✓", name: "Doğru", color: C.green },
+  wrong: { mark: "✗", name: "Yanlış", color: C.red },
+  blank: { mark: "∅", name: "Boş", color: C.yellow },
+};
+let _logFilter = "all";
+function answerLogCard(st) {
+  const c = card("Cevap Günlüğü", "seçilen günde sorulan sorular ve verilen cevaplar");
+  const log = st.answer_log;
+  if (!Array.isArray(log)) {
+    c._body.appendChild(el("div", "empty",
+      "Cevap detayları bu kayıtta yok. Çocuğun Coalide uygulaması güncellendikten sonra, " +
+      "sonraki sorulardan itibaren burada görünecek."));
+    return c;
+  }
+
+  const byDate = new Map();
+  for (const r of log) {
+    if (!byDate.has(r.date)) byDate.set(r.date, []);
+    byDate.get(r.date).push(r);
+  }
+  const dates = [...byDate.keys()].sort();
+  const today = st.today;
+  let day = byDate.has(today) ? today : (dates[dates.length - 1] || today);
+
+  // --- controls -------------------------------------------------------
+  const bar = el("div", "daybar");
+  const prev = txt("button", "nav", "‹"); prev.title = "Önceki gün";
+  const input = document.createElement("input");
+  input.type = "date"; input.value = day;
+  if (dates.length) { input.min = dates[0]; input.max = today > dates[dates.length - 1] ? today : dates[dates.length - 1]; }
+  const next = txt("button", "nav", "›"); next.title = "Sonraki gün";
+  const todayBtn = txt("button", "tgl", "Bugün");
+  bar.append(prev, input, next, todayBtn);
+  bar.appendChild(txt("div", "hint", `son ${num(st.answer_log_days) || 30} günün kaydı · ${dates.length} günde veri var`));
+  c._body.appendChild(bar);
+
+  const chips = el("div", "chips");
+  const filters = [["all", "Tümü"], ["correct", "✓ Doğru"], ["wrong", "✗ Yanlış"], ["blank", "∅ Boş"]];
+  const chipEls = filters.map(([key, label]) => {
+    const b = txt("button", "chip", label);
+    b.setAttribute("aria-pressed", String(key === _logFilter));
+    b.onclick = () => { _logFilter = key; chipEls.forEach((e, i) => e.setAttribute("aria-pressed", String(filters[i][0] === key))); render(); };
+    chips.appendChild(b);
+    return b;
+  });
+  c._body.appendChild(chips);
+
+  const summary = el("div");
+  const body = el("div");
+  c._body.appendChild(summary);
+  c._body.appendChild(body);
+
+  // --- render ---------------------------------------------------------
+  function render() {
+    const all = byDate.get(day) || [];
+    const counts = { correct: 0, wrong: 0, blank: 0 };
+    all.forEach(r => { if (counts[r.result] != null) counts[r.result]++; });
+    const total = all.length;
+    const rate = total ? counts.correct / total * 100 : 0;
+
+    summary.replaceChildren(kpiRow([
+      { label: "Toplam soru", value: total, color: C.purple },
+      { label: "Doğru ✓", value: counts.correct, color: C.green },
+      { label: "Yanlış ✗", value: counts.wrong, color: C.red },
+      { label: "Boş ∅", value: counts.blank, color: C.yellow },
+      { label: "Başarı", value: Math.round(rate), unit: "%", color: rateColor(rate) },
+    ]));
+
+    const rows = _logFilter === "all" ? all : all.filter(r => r.result === _logFilter);
+    body.replaceChildren();
+    if (!total) {
+      body.appendChild(el("div", "empty", "Bu tarihte kayıtlı cevap yok."));
+      return;
+    }
+    if (!rows.length) {
+      body.appendChild(el("div", "empty", "Bu filtreye uyan cevap yok."));
+      return;
+    }
+
+    const wrap = el("div", "table-wrap");
+    const table = el("table"), thead = el("thead"), htr = el("tr");
+    [["Saat", "c-time"], ["Soru", "wrap"], ["Beklenen cevap", "wrap"], ["Çocuğun cevabı", "wrap"], ["Sonuç", ""]]
+      .forEach(([label, cls]) => htr.appendChild(txt("th", cls, label)));
+    thead.appendChild(htr); table.appendChild(thead);
+    const tbody = el("tbody");
+    for (const r of rows) {
+      const meta = RESULT_META[r.result] || { mark: "?", name: r.result, color: C.muted };
+      const tr = el("tr");
+      tr.appendChild(txt("td", "c-time", r.time || "—")).style.color = C.muted;
+      // Older log rows predate the detail columns — all we have is the word.
+      const q = el("td", "wrap");
+      q.appendChild(txt("span", null, r.prompt || r.word)).style.fontWeight = 700;
+      if (r.time) q.appendChild(txt("span", "t-sm", r.time));
+      tr.appendChild(q);
+      tr.appendChild(txt("td", "wrap", r.expected || "—"));
+      const given = el("td", "wrap");
+      if (r.result === "blank" || !r.given) {
+        given.appendChild(txt("span", "given-empty", r.result === "blank" ? "(boş bırakıldı)" : "—"));
+      } else {
+        const g = txt("span", r.result === "wrong" ? "given-wrong" : null, r.given);
+        given.appendChild(g);
+      }
+      tr.appendChild(given);
+      const res = el("td");
+      const badge = txt("span", "badge", `${meta.mark} ${meta.name}`);
+      badge.style.color = meta.color;
+      res.appendChild(badge);
+      tr.appendChild(res);
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody); wrap.appendChild(table);
+    body.appendChild(wrap);
+    if (rows.some(r => !r.prompt && !r.expected)) {
+      body.appendChild(txt("p", "note",
+        "Bazı satırlarda soru ve cevap detayı yok: bunlar uygulama güncellenmeden önce kaydedilmiş, " +
+        "o zaman yalnızca kelime ve sonuç tutuluyordu."));
+    }
+  }
+
+  function goto(d) { day = d; input.value = d; render(); }
+  const shift = n => { const t = new Date(day + "T00:00:00"); t.setDate(t.getDate() + n); goto(t.toISOString().slice(0, 10)); };
+  prev.onclick = () => shift(-1);
+  next.onclick = () => shift(1);
+  todayBtn.onclick = () => goto(today);
+  input.onchange = () => { if (input.value) goto(input.value); };
+
+  render();
+  return c;
+}
+
 function pageHafta(st) {
   const root = el("div", "grid");
+  root.appendChild(gcol(12, answerLogCard(st)));
 
   const da = st.daily_answers || [], daLabels = da.map(r => r[0]);
   const daSeries = [
@@ -1052,6 +1222,15 @@ async function refresh() {
     content.classList.remove("stale");
   }
 }
+// Logo = home. A plain click returns to the default tab without a full reload;
+// ctrl/cmd/middle-click still opens "/" the way any link would.
+document.querySelector(".brand").addEventListener("click", ev => {
+  if (ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.button !== 0) return;
+  ev.preventDefault();
+  _active = Object.keys(PAGES)[0];
+  showPage();
+  window.scrollTo({ top: 0, behavior: "smooth" });
+});
 document.getElementById("refresh").onclick = refresh;
 document.getElementById("user").onchange = refresh;
 refresh();

--- a/serverside/dashboard.html
+++ b/serverside/dashboard.html
@@ -773,12 +773,17 @@ function successCard(st) {
   const c = card("Genel Başarı", "");
   const today = st.today;
 
-  // Older clients don't send the per-day breakdown — show all-time only.
+  // Older clients don't send the per-day breakdown — show all-time only, and
+  // say why the window picker is missing rather than hiding it silently.
   if (!byDate || typeof byDate !== "object") {
     c._ht.appendChild(txt("div", "sub", "tüm kayıtlı cevaplara göre"));
     c._body.appendChild(successBody(st, {
       correct: num(lt.correct), wrong: num(lt.wrong), blank: num(lt.blank),
     }, num(st.overall_rate)));
+    c._body.appendChild(txt("p", "note",
+      "Zaman aralığı seçimi (bugün / dün / bu hafta / bu ay / özel) için çocuğun " +
+      "Coalide uygulamasının güncellenmesi gerekiyor — güncelleme sonrası geçmiş " +
+      "günler de dahil çalışacak."));
     return c;
   }
 

--- a/stats_menu.py
+++ b/stats_menu.py
@@ -341,6 +341,13 @@ def build_stats() -> dict:
     hardest = sorted(attempted, key=lambda e: (e["rate"], -e["wrong"]))[:5]
     table_rows = sorted(started, key=lambda e: (e["rate"], -e["wrong"]))
 
+    # ---- answers per day, whole history (the parent dashboard's "Genel
+    #      Başarı" widget sums these for any chosen window) ----
+    answers_by_date = {
+        d.isoformat(): [c.get("correct", 0), c.get("wrong", 0), c.get("blank", 0)]
+        for d, c in sorted(answers_by_day.items())
+    }
+
     # ---- per-answer detail (recent days only; the parent dashboard's
     #      "Cevap Günlüğü" widget reads this) ----
     log_cutoff = today - timedelta(days=ANSWER_LOG_DAYS - 1)
@@ -441,6 +448,7 @@ def build_stats() -> dict:
         "longest": longest,
         "hardest": hardest,
         "table_rows": table_rows,
+        "answers_by_date": answers_by_date,
         "answer_log": answer_log,
         "answer_log_days": ANSWER_LOG_DAYS,
         "word_types": word_types,

--- a/stats_menu.py
+++ b/stats_menu.py
@@ -14,6 +14,7 @@ Run standalone:  python stats_menu.py
 From the menu:   the "İstatistikler" button launches it as a subprocess.
 """
 
+import csv
 import json
 import os
 from collections import Counter
@@ -46,20 +47,46 @@ MINUTES_PER_DAY = 24 * 60
 # Answer log (statistics.csv) — stdlib only, safe to import from new_master
 # --------------------------------------------------------------------------
 
-def record_answer(word: str, result) -> None:
+LOG_HEADER = ["datetime", "word", "result", "given", "expected", "prompt", "direction"]
+ANSWER_LOG_DAYS = 30  # how far back the per-answer detail is kept in build_stats()
+
+
+def _flat(v) -> str:
+    """A list of accepted meanings -> one displayable string."""
+    if v is None:
+        return ""
+    if isinstance(v, (list, tuple)):
+        return ", ".join(str(x) for x in v)
+    return str(v)
+
+
+def record_answer(word: str, result, given=None, expected=None,
+                  prompt=None, direction=None) -> None:
     """
     Append one answered question to statistics.csv.
+
     :param word: the target word that was asked.
     :param result: True (correct), False (wrong) or None (left blank).
-    Never raises — a stats logging failure must not break the quiz.
+    :param given: what the child actually typed.
+    :param expected: the accepted answer(s) for the question.
+    :param prompt: the text the child was shown.
+    :param direction: "target" if the target word was wanted, else "source".
+
+    The four detail columns were added after the first release, so rows written
+    by an older build only have the first three; readers must tolerate both.
+    Written through csv so a comma inside a word or an answer cannot shift the
+    columns. Never raises — a stats logging failure must not break the quiz.
     """
     try:
         res = "correct" if result is True else "wrong" if result is False else "blank"
         is_new = not os.path.exists(STATS_LOG)
-        with open(STATS_LOG, "a", encoding="utf-8") as f:
+        with open(STATS_LOG, "a", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
             if is_new:
-                f.write("datetime,word,result\n")
-            f.write(f"{datetime.now().isoformat(timespec='seconds')},{word},{res}\n")
+                w.writerow(LOG_HEADER)
+            w.writerow([datetime.now().isoformat(timespec="seconds"), word, res,
+                        _flat(given), _flat(expected), _flat(prompt),
+                        _flat(direction)])
     except Exception:
         pass
 
@@ -83,24 +110,43 @@ def _parse_date(s):
         return None
 
 
-def load_log() -> list:
-    """Read statistics.csv -> list of (date, word, result) tuples."""
+def read_log_rows() -> list:
+    """
+    Read statistics.csv -> list of dicts, one per answered question.
+
+    Rows written before the detail columns existed simply come back with empty
+    given/expected/prompt/direction.
+    """
     rows = []
     if not os.path.exists(STATS_LOG):
         return rows
     try:
-        with open(STATS_LOG, "r", encoding="utf-8") as f:
-            for line in f:
-                parts = line.strip().split(",")
+        with open(STATS_LOG, "r", encoding="utf-8", newline="") as f:
+            for parts in csv.reader(f):
                 if len(parts) < 3 or parts[0].startswith("datetime"):
                     continue
                 d = _parse_date(parts[0][:10])
                 if d is None:
                     continue
-                rows.append((d, parts[1], parts[2]))
+                col = lambda i: parts[i].strip() if len(parts) > i else ""
+                rows.append({
+                    "date": d,
+                    "time": parts[0][11:16],
+                    "word": parts[1],
+                    "result": parts[2],
+                    "given": col(3),
+                    "expected": col(4),
+                    "prompt": col(5),
+                    "direction": col(6),
+                })
     except Exception:
         pass
     return rows
+
+
+def load_log() -> list:
+    """Read statistics.csv -> list of (date, word, result) tuples."""
+    return [(r["date"], r["word"], r["result"]) for r in read_log_rows()]
 
 
 def load_user_data() -> dict:
@@ -164,7 +210,8 @@ def build_stats() -> dict:
     words = _load_json(WORDS_FILE, [])
     if not isinstance(words, list):
         words = []
-    log = load_log()
+    log_rows = read_log_rows()
+    log = [(r["date"], r["word"], r["result"]) for r in log_rows]
     user = load_user_data()
 
     # ---- per-word state ----
@@ -294,6 +341,16 @@ def build_stats() -> dict:
     hardest = sorted(attempted, key=lambda e: (e["rate"], -e["wrong"]))[:5]
     table_rows = sorted(started, key=lambda e: (e["rate"], -e["wrong"]))
 
+    # ---- per-answer detail (recent days only; the parent dashboard's
+    #      "Cevap Günlüğü" widget reads this) ----
+    log_cutoff = today - timedelta(days=ANSWER_LOG_DAYS - 1)
+    answer_log = [
+        {"date": r["date"], "time": r["time"], "word": r["word"],
+         "result": r["result"], "given": r["given"], "expected": r["expected"],
+         "prompt": r["prompt"], "direction": r["direction"]}
+        for r in log_rows if r["date"] >= log_cutoff
+    ]
+
     # ---- word types ----
     word_types = Counter((w.get("word_type") or "?").strip().lower() or "?"
                          for w in words if isinstance(w, dict))
@@ -384,6 +441,8 @@ def build_stats() -> dict:
         "longest": longest,
         "hardest": hardest,
         "table_rows": table_rows,
+        "answer_log": answer_log,
+        "answer_log_days": ANSWER_LOG_DAYS,
         "word_types": word_types,
         "balance": balance,
         "redeemed_14": redeemed_14,


### PR DESCRIPTION
Follows #59 and #60, both merged. Four commits, rebased onto current `main`.

## Cevap Günlüğü — per-day answer log

`statistics.csv` only ever stored `datetime,word,result`, so the dashboard could show *how many* answers were right on a day but not which questions were asked or what the child typed. That data had to be captured at the source first.

**Client** — `record_answer()` now also takes the typed answer, the accepted answer(s), the prompt shown and the question direction, written as four extra CSV columns. Rows from an older build have only the first three and the reader tolerates both. `build_stats()` ships the last 30 days as `answer_log`.

Writing and reading now go through the `csv` module. The previous `line.split(",")` silently corrupted any row whose word or meaning contained a comma — an answer of `sel, tufan` parsed as an extra column.

**Server** — "Haftalık & Günlük" opens with a card holding a date picker (defaulting to today) with prev/next/Bugün, a summary tile row for that day, result filter chips, and a table of every question: time, what was asked, the accepted answer, what the child typed (wrong answers in red), and the grade. Days recorded before this change fall back to the word alone and say so. On phones the time folds under the question so both the question and the answer fit without sideways scrolling.

Detail only exists for answers given after the client updates — the typed answer was never stored, so it cannot be backfilled.

## Genel Başarı — selectable time window

The ring covered all recorded answers and nothing else. It now takes a window: **Tüm zamanlar** (the default, unchanged behaviour), **Bugün**, **Dün**, **Bu hafta**, **Bu ay**, or a custom start/end pair. The subtitle names the active window; ring and tiles recompute together; an empty window says so instead of showing a misleading 0%.

`build_stats()` gains `answers_by_date` — the whole history as `{ISO date: [correct, wrong, blank]}`, one row per day the child answered something — so any window is summed exactly rather than interpolated from the 14- and 30-day series. This one is derived from the existing `statistics.csv`, so it covers all past history from the first push after updating.

Each preset was checked against sums computed independently from the payload:

```
Bugün      79%  45/9/3      expected [45, 9, 3]      79%
Dün        63%  30/14/4     expected [30, 14, 4]     63%
Bu hafta   71%  75/23/7     expected [75, 23, 7]     71%
Bu ay      74%  114/29/12   expected [114, 29, 12]   74%
custom     75%  667/161/59  expected [667, 161, 59]  75%
```

Weeks start Monday, matching the client's own week bucketing. A reversed custom range swaps itself. A payload without `answers_by_date` falls back to the all-time figure and names the reason the picker is absent.

The fourth hero tile is now **Toplam**, which follows the window like the other three; **Seri** moved to Özet with the other whole-account figures, since a streak is not a windowed measure.

## Logos link home

Clicking `COALIDE` on the dashboard returns to the default tab and scrolls to top without a full reload; ctrl/cmd/middle-click still opens `/` as an ordinary link. The admin page's logo is now an anchor to `/` as well, alongside the existing "← Panele dön" link.

## Also

Fixed a latent off-by-one-day bug in the answer log's prev/next buttons: they went through `toISOString()`, which converts to UTC first and lands on the wrong day outside UTC. Both widgets now share a local-time date helper.

## Verification

Driven in a real browser against the running server at 1440px and 390px: all five tabs render, every window preset and the custom range compute correctly, the day picker and result filters work, the legacy-row fallback shows, and the admin logo navigates back to `/`. No page errors and no horizontal overflow at either width. `stats_menu.py`, `new_master.py` and `serverside/server.py` compile clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHUCQK1WEzjy5wtZoNvraf)_