### PR TITLE
Re-sync parent config when returning to the main menu

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -494,6 +494,11 @@ class MainMenu(Screen):
         # redeemed minutes, so re-read them into the stats panel now that the
         # TUI has resumed.
         self.refresh_stats()
+        # Pull parent-made changes again. on_mount only fires once (the quiz
+        # suspends the app instead of switching screens, so returning here
+        # never remounts), and without this a dashboard edit would not reach
+        # the child until the whole app was restarted.
+        sync_config_async()
 
 class ExitDialog(ModalScreen[str | None]):
     """Popup behind the Çıkış button.


### PR DESCRIPTION
## Problem

A config change made on the parental dashboard did not reach the child's device until the whole app was restarted, even though both the code and the dashboard promise it applies on the next menu open.

`sync_config_async()` was only called from `MainMenu.on_mount()`, which fires exactly once at app launch. The quiz and the other sub-flows go through `app.suspend()` + `subprocess.run` rather than a screen change, so returning from one never remounts `MainMenu` — and so never re-syncs.

This contradicted:

- the comment at the import site — *"pulls parent-made changes from the server and applies them locally when the menu opens"* (`menu.py`)
- the toast the dashboard shows the parent — *"Ayarlar kaydedildi. Çocuğun cihazına bir sonraki menü açılışında uygulanacak."* (`serverside/admin.html`)

The rest of the sync chain is fine: the dashboard posts real JSON numbers, `save_config` bumps the rev, and `sync()` returns the payload whenever `cfg["rev"] > applied`. The client just never asked a second time.

## Change

Call `sync_config_async()` once the TUI resumes in `run_python_script`, next to the existing `refresh_stats()`. Five lines, no behaviour change beyond the extra pull.

## Testing

Verified `menu.py` parses and that both call sites are present. The sync itself is unverifiable from this dev checkout — `STATS_SERVER_URL` here is still the shipped placeholder, so `config_sync` skips on the placeholder-marker guard and never hits the wire. Needs a run against a real parental server.

## Known gaps, not addressed here

- The pull is a daemon thread with a 5s HTTP timeout. If the child relaunches the quiz within that window, `new_master.py` reads `config.json` before the write lands and gets the stale value. Self-corrects on the next return to the menu, but it makes testing look flaky.
- `config_sync.py` merges the server's entire snapshot with server-wins precedence, `STATS_SERVER_URL` included. If that key ever holds a placeholder server-side, applying it would overwrite the child's real URL and permanently sever sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
