### PR TITLE
Keep a question's presentation fixed until it is answered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,4 @@ config.json
 current_user.json
 *_data.json
 progress.json
+.pending_question.json

--- a/new_master.py
+++ b/new_master.py
@@ -158,10 +158,7 @@ def quest(user, current_question: Question = None):
         if current_question is None:
             print("No more questions due for review. Come back later!")
             sys.exit(0)
-        if type(current_question.prompt) == list: 
-            import random
-            prompt = random.choice(current_question.prompt)
-        else: prompt = current_question.prompt
+        prompt = current_question.prompt_text
 
         # Providing information
 

--- a/objects/question_obj.py
+++ b/objects/question_obj.py
@@ -3,6 +3,7 @@ Question object will have the following attributes:
 - word: Word
 - is_target_wanted: bool
 - is_source_wanted: bool
+- prompt_index: int
 """
 
 from objects.word_obj import Word
@@ -13,10 +14,12 @@ class Question:
 
     :param word: The Word object associated with this question.
     :param is_target_wanted: A boolean indicating whether the target word is being asked for
+    :param prompt_index: Which alias to show when the prompt side has several (see prompt_text).
     """
-    def __init__(self, word: Word, is_target_wanted: bool):
+    def __init__(self, word: Word, is_target_wanted: bool, prompt_index: int = 0):
         self.word = word
         self.is_target_wanted = is_target_wanted
+        self.prompt_index = prompt_index
 
     @property
     def is_source_wanted(self) -> bool:
@@ -25,6 +28,20 @@ class Question:
     @property
     def prompt(self) -> str:
         return self.word.source if self.is_target_wanted else self.word.target
+
+    @property
+    def prompt_text(self) -> str:
+        """
+        The single prompt actually put on screen. The prompt side often has
+        several aliases ("almak" / "elde etmek" for "get"); prompt_index picks
+        which one, and is held fixed until the question is answered so leaving
+        and re-entering the quiz can't re-roll it into a different hint
+        (see sm2.PENDING_FILE).
+        """
+        prompt = self.prompt
+        if isinstance(prompt, list):
+            return prompt[self.prompt_index % len(prompt)] if prompt else ""
+        return prompt
 
     @property
     def expected_answer(self) -> str:

--- a/sm2.py
+++ b/sm2.py
@@ -21,10 +21,12 @@ SHUFFLE_NEW_WORDS = config.get("SHUFFLE_NEW_WORDS", False) # introduce new words
 
 NEW_WORD_SENTINEL = "2020-10-10" # next_review_date assigned to brand-new (never-reviewed) words
 
-# Direction of the question currently on screen, remembered on disk. Without it
-# a kid could type "exit" and restart the quiz to re-roll the same word into the
-# other direction -- and the easy direction shows them the answer they were just
-# asked for. Only one question is ever pending, so a single slot is enough.
+# Everything randomized about the question currently on screen -- the direction
+# and, when the prompt side has aliases, which one is shown -- remembered on
+# disk. Without this a kid could type "exit" and restart the quiz to re-roll:
+# the other direction shows them the answer they were just asked for, and a
+# different alias is a second free hint at the same answer. Only one question is
+# ever pending, so a single slot is enough.
 #
 # Deliberately NOT stored in progress.json: every key there counts as a "started"
 # word in the stats screen (see stats_menu.build_stats), and merely being shown a
@@ -32,8 +34,12 @@ NEW_WORD_SENTINEL = "2020-10-10" # next_review_date assigned to brand-new (never
 PENDING_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".pending_question.json")
 
 
-def _load_pending_direction(word_id: str) -> bool | None:
-    """The saved direction for `word_id`, or None when nothing is pending for it."""
+def _load_pending_question(word_id: str) -> tuple[bool, int] | None:
+    """
+    The saved (direction, prompt_index) for `word_id`, or None when nothing is
+    pending for it. A slot written before prompt_index existed still loads, as
+    index 0.
+    """
     try:
         with open(PENDING_FILE, "r", encoding="UTF-8") as f:
             pending = json.load(f)
@@ -42,23 +48,39 @@ def _load_pending_direction(word_id: str) -> bool | None:
     if not isinstance(pending, dict) or pending.get("word_id") != word_id:
         return None
     direction = pending.get("is_target_wanted")
-    return direction if isinstance(direction, bool) else None
+    if not isinstance(direction, bool):
+        return None
+    index = pending.get("prompt_index", 0)
+    return direction, index if isinstance(index, int) and index >= 0 else 0
 
 
-def _save_pending_direction(word_id: str, is_target_wanted: bool) -> None:
+def _save_pending_question(word_id: str, is_target_wanted: bool, prompt_index: int) -> None:
     try:
         with open(PENDING_FILE, "w", encoding="UTF-8") as f:
-            json.dump({"word_id": word_id, "is_target_wanted": is_target_wanted}, f)
+            json.dump({"word_id": word_id, "is_target_wanted": is_target_wanted,
+                       "prompt_index": prompt_index}, f)
     except OSError:
-        lg("Could not save the pending question direction.")  # must never break the quiz
+        lg("Could not save the pending question.")  # must never break the quiz
 
 
-def _clear_pending_direction() -> None:
-    """Forget the pending direction once its question has been answered."""
+def _clear_pending_question() -> None:
+    """Forget the pending question once it has been answered."""
     try:
         os.remove(PENDING_FILE)
     except OSError:
         pass  # already gone (or unwritable) -- nothing to forget either way
+
+
+def _random_prompt_index(word: Word, is_target_wanted: bool) -> int:
+    """
+    Pick which alias to show when the prompt side has several ("almak" / "elde
+    etmek" for "get"); 0 when that side is a plain string. Goes through a
+    throwaway Question so the "which side is the prompt" rule stays in one place.
+    """
+    prompt = Question(word=word, is_target_wanted=is_target_wanted).prompt
+    if isinstance(prompt, list) and prompt:
+        return random.randrange(len(prompt))
+    return 0
 
 
 def _order_word_list(words: list[Word]):
@@ -146,13 +168,18 @@ def get_next_question(feed: list | None = None) -> Question:
         due_words = due_words_filtered
  
     next_word = due_words[0]
-    # Reuse the direction if this word was already put on screen and left
-    # unanswered, so quitting and restarting can't re-roll it (see PENDING_FILE).
-    is_target_wanted = _load_pending_direction(next_word.id)
-    if is_target_wanted is None:
+    # Reuse the presentation -- direction and which alias is shown -- if this
+    # word was already put on screen and left unanswered, so quitting and
+    # restarting can't re-roll either of them (see PENDING_FILE).
+    pending = _load_pending_question(next_word.id)
+    if pending is None:
         is_target_wanted = random.randint(0, 1) == 1
-        _save_pending_direction(next_word.id, is_target_wanted)
-    return Question(word=next_word, is_target_wanted=is_target_wanted)
+        prompt_index = _random_prompt_index(next_word, is_target_wanted)
+        _save_pending_question(next_word.id, is_target_wanted, prompt_index)
+    else:
+        is_target_wanted, prompt_index = pending
+    return Question(word=next_word, is_target_wanted=is_target_wanted,
+                    prompt_index=prompt_index)
 
 def calculate_quality(is_correct, word_length:int, time_taken: float) -> int:
     """
@@ -205,6 +232,6 @@ def update_sm2(word, quality: int):
         word.first_review_date = date.today().isoformat()  # first ever review = word introduced today
     word.last_review_date = date.today().isoformat()  # Update the last review date to today
     save_progress(word)  # Save the updated word progress to progress.json
-    _clear_pending_direction()  # answered -- the next outing re-rolls the direction
+    _clear_pending_question()  # answered -- the next outing re-rolls the presentation
     return word
 

--- a/sm2.py
+++ b/sm2.py
@@ -9,6 +9,8 @@ from operator import attrgetter
 from objects.word_obj import Word,save_progress
 from objects.question_obj import Question
 from utils import lg,get_config
+import json
+import os
 import random
 
 config = get_config()
@@ -18,6 +20,45 @@ NO_REPEAT_WINDOW = config.get("No_Repeat_Window", 8) # a word can't repeat withi
 SHUFFLE_NEW_WORDS = config.get("SHUFFLE_NEW_WORDS", False) # introduce new words in random order instead of words.json order
 
 NEW_WORD_SENTINEL = "2020-10-10" # next_review_date assigned to brand-new (never-reviewed) words
+
+# Direction of the question currently on screen, remembered on disk. Without it
+# a kid could type "exit" and restart the quiz to re-roll the same word into the
+# other direction -- and the easy direction shows them the answer they were just
+# asked for. Only one question is ever pending, so a single slot is enough.
+#
+# Deliberately NOT stored in progress.json: every key there counts as a "started"
+# word in the stats screen (see stats_menu.build_stats), and merely being shown a
+# question shouldn't move those numbers.
+PENDING_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".pending_question.json")
+
+
+def _load_pending_direction(word_id: str) -> bool | None:
+    """The saved direction for `word_id`, or None when nothing is pending for it."""
+    try:
+        with open(PENDING_FILE, "r", encoding="UTF-8") as f:
+            pending = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(pending, dict) or pending.get("word_id") != word_id:
+        return None
+    direction = pending.get("is_target_wanted")
+    return direction if isinstance(direction, bool) else None
+
+
+def _save_pending_direction(word_id: str, is_target_wanted: bool) -> None:
+    try:
+        with open(PENDING_FILE, "w", encoding="UTF-8") as f:
+            json.dump({"word_id": word_id, "is_target_wanted": is_target_wanted}, f)
+    except OSError:
+        lg("Could not save the pending question direction.")  # must never break the quiz
+
+
+def _clear_pending_direction() -> None:
+    """Forget the pending direction once its question has been answered."""
+    try:
+        os.remove(PENDING_FILE)
+    except OSError:
+        pass  # already gone (or unwritable) -- nothing to forget either way
 
 
 def _order_word_list(words: list[Word]):
@@ -105,7 +146,12 @@ def get_next_question(feed: list | None = None) -> Question:
         due_words = due_words_filtered
  
     next_word = due_words[0]
-    is_target_wanted = random.randint(0, 1) == 1
+    # Reuse the direction if this word was already put on screen and left
+    # unanswered, so quitting and restarting can't re-roll it (see PENDING_FILE).
+    is_target_wanted = _load_pending_direction(next_word.id)
+    if is_target_wanted is None:
+        is_target_wanted = random.randint(0, 1) == 1
+        _save_pending_direction(next_word.id, is_target_wanted)
     return Question(word=next_word, is_target_wanted=is_target_wanted)
 
 def calculate_quality(is_correct, word_length:int, time_taken: float) -> int:
@@ -159,5 +205,6 @@ def update_sm2(word, quality: int):
         word.first_review_date = date.today().isoformat()  # first ever review = word introduced today
     word.last_review_date = date.today().isoformat()  # Update the last review date to today
     save_progress(word)  # Save the updated word progress to progress.json
+    _clear_pending_direction()  # answered -- the next outing re-rolls the direction
     return word
 


### PR DESCRIPTION
## Problem

Two things about a question were rolled fresh every time `get_next_question()` ran, so a kid could type `exit`, restart the quiz, get the same due word back, and re-roll them:

1. **Direction** — `is_target_wanted = random.randint(0, 1) == 1` (`sm2.py`). The other direction shows them the answer they were just asked for.
2. **Which alias is shown** — `prompt = random.choice(current_question.prompt)` (`new_master.py`), whenever the prompt side has several. A different alias is a second free hint at the same answer.

Neither is a corner case: 1321 of the 3012 words carry more than one source alias (`get` → `['almak', 'elde etmek']`).

## Change

Remember the whole randomized presentation of the question currently on screen — direction *and* alias index — and reuse it when the same word comes back up. `update_sm2()` forgets it once the answer has actually been graded.

The exploit closes because of where the exit path sits: typing `exit` breaks out of `quest()` *before* `add_result`/`update_sm2` ever run, so the presentation stays pending across the restart. Quitting via the post-answer `[Q]` menu happens after grading, so that path still re-rolls normally on the next scheduled review.

The alias choice also moves out of `quest()` into `Question.prompt_text`, with `sm2` picking the index — `quest()` no longer rolls anything of its own. Only one question is ever pending, so the state is a single slot.

## Why not `progress.json`

Every key there counts as a *started* word in the stats screen — `stats_menu.build_stats` derives `started_count`, the "Başlanmadı" bucket and the new-words-per-day charts from `progress.items()`. Persisting there would make merely *being shown* a question move those numbers, most visibly for brand-new words, which have no progress entry until they're first answered. Hence a separate `.pending_question.json` (gitignored).

## Testing

- 30 simulated restarts on the same due word → identical direction *and* identical prompt text every time. On `main` both are a fresh roll per launch.
- After the pending state clears, repeated rolls produce multiple distinct presentations — randomness intact for genuine new outings.
- `_random_prompt_index` varies over `[0, 1]` when the prompt side is an alias list, and is always `0` when it's a plain string.
- A different `word_id` does not inherit another word's stored presentation.
- Robustness: corrupt/unparseable state file → "nothing pending" rather than a throw; a non-integer `prompt_index` falls back to 0; an out-of-range index is taken modulo the alias count so it cannot `IndexError` mid-quiz; slots written before `prompt_index` existed still load, as index 0; write failures are swallowed so remembering this can never break the quiz.

## Known gap

If a kid quits on word A and a *different* word happens to come up first next session, A's presentation is forgotten and will re-roll later. Not exploitable — they can't choose which word comes first — but it's the one hole in the guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
