### PR TITLE
Show app version at bottom-center of the main menu

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -50,6 +50,21 @@ except Exception:
 # Change this to wherever your quiz script actually lives.
 APP_PATH = "new_master.py"
 
+# Version string shown, dimmed, at the bottom-center of the menu. Read from
+# version.json if it exists (written by the updater in coalide.py), otherwise
+# fall back to this default.
+FALLBACK_VERSION = "v2.0.0-alpha"
+
+
+def _app_version() -> str:
+    """Return the installed version from version.json, or the fallback."""
+    try:
+        import json
+        with open("version.json", "r", encoding="utf-8") as f:
+            return json.load(f).get("version") or FALLBACK_VERSION
+    except Exception:
+        return FALLBACK_VERSION
+
 
 # Inspirational quotes shown at the bottom of the menu — one picked at random
 # each time the menu opens. A mix of Harry Potter, Star Wars, Star Trek and a
@@ -263,6 +278,14 @@ class MainMenu(Screen):
         color: #cfcfe8;
         margin-bottom: 1;
     }
+
+    #version {
+        height: 1;
+        content-align: center middle;
+        text-align: center;
+        color: #6b6b80;
+        text-style: dim;
+    }
     """
 
     def compose(self) -> ComposeResult:
@@ -285,6 +308,7 @@ class MainMenu(Screen):
                 yield Static(self._used_text(user), id="stat-used", classes="stat-row")
                 # Easter egg: click this quote to re-roll it (see on_click).
                 yield Static(self._random_quote_text(), id="quote")
+        yield Static(_app_version(), id="version")
         yield Footer(show_command_palette=False)
 
     @staticmethod


### PR DESCRIPTION
## What

Adds a small, dimmed version line centered at the bottom of the main menu, just above the footer.

## Details

- New `_app_version()` helper reads `version.json` (written by the updater in `coalide.py`) when present, and falls back to a compiled-in `FALLBACK_VERSION` otherwise — so it shows the installed version once the updater has run, and a sensible default before then.
- Styled in gray tones (`#6b6b80` + `text-style: dim`), horizontally centered, single line.

## Notes

- The banner still reads `V2`; this footer is tied to the changelog version (`v2.0.0-alpha`). Happy to align them if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)