### PR TITLE
Reset word maturity buckets to "not started" (in-app admin + serverside dashboard)

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -98,15 +98,21 @@ def _rename_progress(old_target: str, new_target: str):
 
 
 # SM-2 interval (days) ranges for the stats-screen maturity buckets, used by the
-# "reset to not started" actions — see stats_menu.build_stats. Each button
-# targets one bucket independently, so they can be reset separately or together.
-#   Yeni (≤1 gün):        0 ≤ interval ≤ 1
-#   Öğreniliyor (2-6g):   2 ≤ interval ≤ 6
-NEW_WORD_RANGE = (0, 1)
-LEARNING_RANGE = (2, 6)
+# "reset to not started" actions — see stats_menu.build_stats (MATURE_INTERVAL=21).
+# Each bucket gets its own reset button, so any can be reset independently (or
+# several together). Each row is (button/dialog label, (lo, hi)) with lo/hi
+# inclusive; the last bucket runs to infinity.
+#   (id_suffix, label, (lo_interval, hi_interval))
+RESET_BUCKETS = [
+    ("new",      "Yeni (≤1 gün)",      (0, 1)),
+    ("learning", "Öğreniliyor (2-6g)", (2, 6)),
+    ("young",    "Genç (1-3 hafta)",   (7, 20)),
+    ("mature",   "Olgun (3h-2 ay)",    (21, 59)),
+    ("master",   "Usta (2 ay +)",      (60, float("inf"))),
+]
 
 
-def _targets_in_interval_range(lo: int, hi: int) -> list[str]:
+def _targets_in_interval_range(lo: float, hi: float) -> list[str]:
     """Targets of started words whose SM-2 interval falls in [lo, hi] (inclusive).
     Missing/odd intervals count as 0, so they land in the lowest bucket."""
     prog = _load_json(PROGRESS_FILE, {})
@@ -141,7 +147,7 @@ def _backup_progress() -> str | None:
         return None
 
 
-def _reset_progress_in_range(lo: int, hi: int) -> tuple[int, str | None]:
+def _reset_progress_in_range(lo: float, hi: float) -> tuple[int, str | None]:
     """Remove the progress entry of every started word with interval in [lo, hi],
     sending those words back to 'not started'. Backs progress.json up first.
     Returns (count_removed, backup_path)."""
@@ -376,6 +382,9 @@ class AdminApp(App):
     /* Words tab */
     .words-toolbar {{ height: auto; margin-bottom: 1; }}
     .words-toolbar Button {{ margin-right: 1; }}
+    .words-reset-toolbar {{ height: auto; margin-bottom: 1; }}
+    .words-reset-toolbar Button {{ margin-right: 1; }}
+    .reset-label {{ width: auto; padding: 1 1; color: {MUTED}; }}
     #word-count {{ width: 1fr; text-align: right; padding: 1 2; color: {MUTED}; }}
     #words-table {{ height: 1fr; background: {PANEL_BG}; }}
 
@@ -602,9 +611,12 @@ class AdminApp(App):
             yield Button("➕ Kelime Ekle", variant="success", id="btn-word-add")
             yield Button("✏️ Düzenle", variant="primary", id="btn-word-edit")
             yield Button("🗑 Sil", variant="error", id="btn-word-delete")
-            yield Button("♻️ Yenileri Sıfırla", variant="warning", id="btn-word-reset-new")
-            yield Button("♻️ Öğrenilenleri Sıfırla", variant="warning", id="btn-word-reset-learning")
             yield Static("", id="word-count")
+        with Horizontal(classes="words-reset-toolbar"):
+            yield Static("♻️ Başlanmadıya döndür:", classes="reset-label")
+            for suffix, label, _range in RESET_BUCKETS:
+                yield Button(label, variant="warning", classes="reset-btn",
+                             id=f"btn-word-reset-{suffix}")
         yield DataTable(id="words-table")
 
     def _refill_words_table(self) -> None:
@@ -711,15 +723,15 @@ class AdminApp(App):
             f"[{MUTED}]Kelimeyle birlikte ilerleme (SM-2) kaydı da silinir. "
             f"Bu işlem geri alınamaz.[/]"), handle)
 
-    @on(Button.Pressed, "#btn-word-reset-new")
-    def _on_word_reset_new(self) -> None:
-        self._reset_words_to_not_started(NEW_WORD_RANGE, "Yeni (≤1 gün)")
+    @on(Button.Pressed, ".reset-btn")
+    def _on_word_reset(self, event: Button.Pressed) -> None:
+        suffix = (event.button.id or "").removeprefix("btn-word-reset-")
+        for s, label, interval_range in RESET_BUCKETS:
+            if s == suffix:
+                self._reset_words_to_not_started(interval_range, label)
+                return
 
-    @on(Button.Pressed, "#btn-word-reset-learning")
-    def _on_word_reset_learning(self) -> None:
-        self._reset_words_to_not_started(LEARNING_RANGE, "Öğreniliyor (2-6g)")
-
-    def _reset_words_to_not_started(self, interval_range: tuple[int, int],
+    def _reset_words_to_not_started(self, interval_range: tuple[float, float],
                                     label: str) -> None:
         """Send every started word whose interval is in interval_range back to
         'Başlanmadı'. Useful when a review backlog has piled up: these

--- a/admin.py
+++ b/admin.py
@@ -97,15 +97,18 @@ def _rename_progress(old_target: str, new_target: str):
         _save_json(PROGRESS_FILE, prog)
 
 
-# Interval (days) at or below which a started word still counts as "Yeni
-# (≤1 gün)" in the stats screen — see stats_menu.build_stats. These are the
-# barely-retained words the "reset new words" action sends back to "not started".
+# SM-2 interval (days) upper bounds for the stats-screen maturity buckets, used
+# by the "reset to not started" actions — see stats_menu.build_stats.
+#   Yeni (≤1 gün):        interval ≤ 1
+#   Öğreniliyor (2-6g):   2 ≤ interval ≤ 6
+# So "Yeni + Öğreniliyor" together is interval ≤ 6.
 NEW_WORD_MAX_INTERVAL = 1
+LEARNING_MAX_INTERVAL = 6
 
 
-def _new_word_targets() -> list[str]:
-    """Targets of started words whose SM-2 interval is ≤ NEW_WORD_MAX_INTERVAL —
-    the 'Yeni (≤1 gün)' bucket. Missing/odd intervals count as new (0)."""
+def _targets_up_to_interval(max_interval: int) -> list[str]:
+    """Targets of started words whose SM-2 interval is ≤ max_interval.
+    Missing/odd intervals count as new (0), so they are always included."""
     prog = _load_json(PROGRESS_FILE, {})
     if not isinstance(prog, dict):
         return []
@@ -116,7 +119,7 @@ def _new_word_targets() -> list[str]:
         interval = entry.get("interval", 0)
         if not isinstance(interval, (int, float)):
             interval = 0
-        if interval <= NEW_WORD_MAX_INTERVAL:
+        if interval <= max_interval:
             out.append(target)
     return out
 
@@ -138,11 +141,11 @@ def _backup_progress() -> str | None:
         return None
 
 
-def _reset_new_progress() -> tuple[int, str | None]:
-    """Remove every 'Yeni (≤1 gün)' word's progress entry, sending those words
-    back to 'not started'. Backs progress.json up first. Returns
-    (count_removed, backup_path)."""
-    targets = _new_word_targets()
+def _reset_progress_up_to(max_interval: int) -> tuple[int, str | None]:
+    """Remove the progress entry of every started word with interval ≤
+    max_interval, sending those words back to 'not started'. Backs progress.json
+    up first. Returns (count_removed, backup_path)."""
+    targets = _targets_up_to_interval(max_interval)
     if not targets:
         return 0, None
     backup = _backup_progress()
@@ -600,6 +603,7 @@ class AdminApp(App):
             yield Button("✏️ Düzenle", variant="primary", id="btn-word-edit")
             yield Button("🗑 Sil", variant="error", id="btn-word-delete")
             yield Button("♻️ Yenileri Sıfırla", variant="warning", id="btn-word-reset-new")
+            yield Button("♻️ Yeni+Öğr. Sıfırla", variant="warning", id="btn-word-reset-learning")
             yield Static("", id="word-count")
         yield DataTable(id="words-table")
 
@@ -709,25 +713,34 @@ class AdminApp(App):
 
     @on(Button.Pressed, "#btn-word-reset-new")
     def _on_word_reset_new(self) -> None:
-        """Send every 'Yeni (≤1 gün)' word back to 'Başlanmadı'. Useful when a
-        review backlog has piled up: these barely-retained words drop out of the
-        due queue and are re-introduced gradually under the daily new-word cap."""
-        targets = _new_word_targets()
+        self._reset_words_to_not_started(NEW_WORD_MAX_INTERVAL, "Yeni (≤1 gün)")
+
+    @on(Button.Pressed, "#btn-word-reset-learning")
+    def _on_word_reset_learning(self) -> None:
+        self._reset_words_to_not_started(LEARNING_MAX_INTERVAL, "Yeni + Öğreniliyor (≤6g)")
+
+    def _reset_words_to_not_started(self, max_interval: int, label: str) -> None:
+        """Send every started word with interval ≤ max_interval back to
+        'Başlanmadı'. Useful when a review backlog has piled up: these
+        barely-retained words drop out of the due queue and are re-introduced
+        gradually under the daily new-word cap. `label` names the affected
+        bucket in the dialog/notice."""
+        targets = _targets_up_to_interval(max_interval)
         if not targets:
-            self.notify("Sıfırlanacak 'Yeni (≤1 gün)' kelime yok.",
+            self.notify(f"Sıfırlanacak '{label}' kelime yok.",
                         title="ℹ️ Bilgi", timeout=4)
             return
 
         def handle(confirmed: bool | None) -> None:
             if not confirmed:
                 return
-            count, backup = _reset_new_progress()
-            msg = f"{count} 'Yeni' kelime 'Başlanmadı' durumuna döndürüldü."
+            count, backup = _reset_progress_up_to(max_interval)
+            msg = f"{count} kelime 'Başlanmadı' durumuna döndürüldü."
             if backup:
                 msg += f"\nYedek: {os.path.basename(backup)}"
             self.notify(msg, title="♻️ Sıfırlandı", timeout=6)
         self.push_screen(ConfirmScreen(
-            f"[bold {YELLOW}]{len(targets)}[/] adet 'Yeni (≤1 gün)' kelime "
+            f"[bold {YELLOW}]{len(targets)}[/] adet '{label}' kelime "
             f"[bold]'Başlanmadı'[/] durumuna döndürülsün mü?\n\n"
             f"[{MUTED}]Bu kelimelerin SM-2 ilerlemesi silinir; günlük yeni "
             f"kelime sınırına tabi olarak kademeli yeniden tanıtılırlar. "

--- a/admin.py
+++ b/admin.py
@@ -97,6 +97,62 @@ def _rename_progress(old_target: str, new_target: str):
         _save_json(PROGRESS_FILE, prog)
 
 
+# Interval (days) at or below which a started word still counts as "Yeni
+# (≤1 gün)" in the stats screen — see stats_menu.build_stats. These are the
+# barely-retained words the "reset new words" action sends back to "not started".
+NEW_WORD_MAX_INTERVAL = 1
+
+
+def _new_word_targets() -> list[str]:
+    """Targets of started words whose SM-2 interval is ≤ NEW_WORD_MAX_INTERVAL —
+    the 'Yeni (≤1 gün)' bucket. Missing/odd intervals count as new (0)."""
+    prog = _load_json(PROGRESS_FILE, {})
+    if not isinstance(prog, dict):
+        return []
+    out = []
+    for target, entry in prog.items():
+        if not isinstance(entry, dict):
+            continue
+        interval = entry.get("interval", 0)
+        if not isinstance(interval, (int, float)):
+            interval = 0
+        if interval <= NEW_WORD_MAX_INTERVAL:
+            out.append(target)
+    return out
+
+
+def _backup_progress() -> str | None:
+    """Copy progress.json to a timestamped .bak before a bulk change, so the
+    reset is always recoverable. Returns the backup path, or None if there was
+    nothing to back up (or the copy failed)."""
+    if not os.path.exists(PROGRESS_FILE):
+        return None
+    try:
+        import shutil
+        from datetime import datetime
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup = f"{PROGRESS_FILE}.{stamp}.bak"
+        shutil.copy2(PROGRESS_FILE, backup)
+        return backup
+    except Exception:
+        return None
+
+
+def _reset_new_progress() -> tuple[int, str | None]:
+    """Remove every 'Yeni (≤1 gün)' word's progress entry, sending those words
+    back to 'not started'. Backs progress.json up first. Returns
+    (count_removed, backup_path)."""
+    targets = _new_word_targets()
+    if not targets:
+        return 0, None
+    backup = _backup_progress()
+    prog = _load_json(PROGRESS_FILE, {})
+    for target in targets:
+        prog.pop(target, None)
+    _save_json(PROGRESS_FILE, prog)
+    return len(targets), backup
+
+
 # --------------------------------------------------------------------------
 # Textual UI
 # --------------------------------------------------------------------------
@@ -543,6 +599,7 @@ class AdminApp(App):
             yield Button("➕ Kelime Ekle", variant="success", id="btn-word-add")
             yield Button("✏️ Düzenle", variant="primary", id="btn-word-edit")
             yield Button("🗑 Sil", variant="error", id="btn-word-delete")
+            yield Button("♻️ Yenileri Sıfırla", variant="warning", id="btn-word-reset-new")
             yield Static("", id="word-count")
         yield DataTable(id="words-table")
 
@@ -649,6 +706,32 @@ class AdminApp(App):
             f"[bold {RED}]'{escape(target)}'[/] kelimesi silinsin mi?\n\n"
             f"[{MUTED}]Kelimeyle birlikte ilerleme (SM-2) kaydı da silinir. "
             f"Bu işlem geri alınamaz.[/]"), handle)
+
+    @on(Button.Pressed, "#btn-word-reset-new")
+    def _on_word_reset_new(self) -> None:
+        """Send every 'Yeni (≤1 gün)' word back to 'Başlanmadı'. Useful when a
+        review backlog has piled up: these barely-retained words drop out of the
+        due queue and are re-introduced gradually under the daily new-word cap."""
+        targets = _new_word_targets()
+        if not targets:
+            self.notify("Sıfırlanacak 'Yeni (≤1 gün)' kelime yok.",
+                        title="ℹ️ Bilgi", timeout=4)
+            return
+
+        def handle(confirmed: bool | None) -> None:
+            if not confirmed:
+                return
+            count, backup = _reset_new_progress()
+            msg = f"{count} 'Yeni' kelime 'Başlanmadı' durumuna döndürüldü."
+            if backup:
+                msg += f"\nYedek: {os.path.basename(backup)}"
+            self.notify(msg, title="♻️ Sıfırlandı", timeout=6)
+        self.push_screen(ConfirmScreen(
+            f"[bold {YELLOW}]{len(targets)}[/] adet 'Yeni (≤1 gün)' kelime "
+            f"[bold]'Başlanmadı'[/] durumuna döndürülsün mü?\n\n"
+            f"[{MUTED}]Bu kelimelerin SM-2 ilerlemesi silinir; günlük yeni "
+            f"kelime sınırına tabi olarak kademeli yeniden tanıtılırlar. "
+            f"progress.json otomatik yedeklenir.[/]"), handle)
 
 
 # --------------------------------------------------------------------------

--- a/admin.py
+++ b/admin.py
@@ -97,18 +97,18 @@ def _rename_progress(old_target: str, new_target: str):
         _save_json(PROGRESS_FILE, prog)
 
 
-# SM-2 interval (days) upper bounds for the stats-screen maturity buckets, used
-# by the "reset to not started" actions — see stats_menu.build_stats.
-#   Yeni (≤1 gün):        interval ≤ 1
+# SM-2 interval (days) ranges for the stats-screen maturity buckets, used by the
+# "reset to not started" actions — see stats_menu.build_stats. Each button
+# targets one bucket independently, so they can be reset separately or together.
+#   Yeni (≤1 gün):        0 ≤ interval ≤ 1
 #   Öğreniliyor (2-6g):   2 ≤ interval ≤ 6
-# So "Yeni + Öğreniliyor" together is interval ≤ 6.
-NEW_WORD_MAX_INTERVAL = 1
-LEARNING_MAX_INTERVAL = 6
+NEW_WORD_RANGE = (0, 1)
+LEARNING_RANGE = (2, 6)
 
 
-def _targets_up_to_interval(max_interval: int) -> list[str]:
-    """Targets of started words whose SM-2 interval is ≤ max_interval.
-    Missing/odd intervals count as new (0), so they are always included."""
+def _targets_in_interval_range(lo: int, hi: int) -> list[str]:
+    """Targets of started words whose SM-2 interval falls in [lo, hi] (inclusive).
+    Missing/odd intervals count as 0, so they land in the lowest bucket."""
     prog = _load_json(PROGRESS_FILE, {})
     if not isinstance(prog, dict):
         return []
@@ -119,7 +119,7 @@ def _targets_up_to_interval(max_interval: int) -> list[str]:
         interval = entry.get("interval", 0)
         if not isinstance(interval, (int, float)):
             interval = 0
-        if interval <= max_interval:
+        if lo <= interval <= hi:
             out.append(target)
     return out
 
@@ -141,11 +141,11 @@ def _backup_progress() -> str | None:
         return None
 
 
-def _reset_progress_up_to(max_interval: int) -> tuple[int, str | None]:
-    """Remove the progress entry of every started word with interval ≤
-    max_interval, sending those words back to 'not started'. Backs progress.json
-    up first. Returns (count_removed, backup_path)."""
-    targets = _targets_up_to_interval(max_interval)
+def _reset_progress_in_range(lo: int, hi: int) -> tuple[int, str | None]:
+    """Remove the progress entry of every started word with interval in [lo, hi],
+    sending those words back to 'not started'. Backs progress.json up first.
+    Returns (count_removed, backup_path)."""
+    targets = _targets_in_interval_range(lo, hi)
     if not targets:
         return 0, None
     backup = _backup_progress()
@@ -603,7 +603,7 @@ class AdminApp(App):
             yield Button("✏️ Düzenle", variant="primary", id="btn-word-edit")
             yield Button("🗑 Sil", variant="error", id="btn-word-delete")
             yield Button("♻️ Yenileri Sıfırla", variant="warning", id="btn-word-reset-new")
-            yield Button("♻️ Yeni+Öğr. Sıfırla", variant="warning", id="btn-word-reset-learning")
+            yield Button("♻️ Öğrenilenleri Sıfırla", variant="warning", id="btn-word-reset-learning")
             yield Static("", id="word-count")
         yield DataTable(id="words-table")
 
@@ -713,19 +713,21 @@ class AdminApp(App):
 
     @on(Button.Pressed, "#btn-word-reset-new")
     def _on_word_reset_new(self) -> None:
-        self._reset_words_to_not_started(NEW_WORD_MAX_INTERVAL, "Yeni (≤1 gün)")
+        self._reset_words_to_not_started(NEW_WORD_RANGE, "Yeni (≤1 gün)")
 
     @on(Button.Pressed, "#btn-word-reset-learning")
     def _on_word_reset_learning(self) -> None:
-        self._reset_words_to_not_started(LEARNING_MAX_INTERVAL, "Yeni + Öğreniliyor (≤6g)")
+        self._reset_words_to_not_started(LEARNING_RANGE, "Öğreniliyor (2-6g)")
 
-    def _reset_words_to_not_started(self, max_interval: int, label: str) -> None:
-        """Send every started word with interval ≤ max_interval back to
+    def _reset_words_to_not_started(self, interval_range: tuple[int, int],
+                                    label: str) -> None:
+        """Send every started word whose interval is in interval_range back to
         'Başlanmadı'. Useful when a review backlog has piled up: these
         barely-retained words drop out of the due queue and are re-introduced
         gradually under the daily new-word cap. `label` names the affected
         bucket in the dialog/notice."""
-        targets = _targets_up_to_interval(max_interval)
+        lo, hi = interval_range
+        targets = _targets_in_interval_range(lo, hi)
         if not targets:
             self.notify(f"Sıfırlanacak '{label}' kelime yok.",
                         title="ℹ️ Bilgi", timeout=4)
@@ -734,7 +736,7 @@ class AdminApp(App):
         def handle(confirmed: bool | None) -> None:
             if not confirmed:
                 return
-            count, backup = _reset_progress_up_to(max_interval)
+            count, backup = _reset_progress_in_range(lo, hi)
             msg = f"{count} kelime 'Başlanmadı' durumuna döndürüldü."
             if backup:
                 msg += f"\nYedek: {os.path.basename(backup)}"

--- a/config_sync.py
+++ b/config_sync.py
@@ -86,6 +86,53 @@ def _reconcile_progress(words: list) -> None:
         _save_json(PROGRESS_FILE, pruned)
 
 
+def _backup_progress():
+    """Copy progress.json to a timestamped .bak before a parent-queued bulk
+    reset, so it stays recoverable. Best-effort; never raises."""
+    if not os.path.exists(PROGRESS_FILE):
+        return None
+    try:
+        import shutil
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup = f"{PROGRESS_FILE}.{stamp}.bak"
+        shutil.copy2(PROGRESS_FILE, backup)
+        return backup
+    except Exception:
+        return None
+
+
+def _apply_progress_resets(jobs: list) -> int:
+    """Apply parent-queued reset jobs: remove every progress entry whose SM-2
+    interval falls in a job's [lo, hi] range, sending those words back to 'not
+    started'. Backs progress.json up first. Returns the number of entries removed."""
+    prog = _load_json(PROGRESS_FILE, None)
+    if not isinstance(prog, dict) or not prog:
+        return 0
+    remove = set()
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        try:
+            lo = float(job.get("lo", 0))
+            hi = float(job.get("hi", 0))
+        except (TypeError, ValueError):
+            continue
+        for target, entry in prog.items():
+            if not isinstance(entry, dict):
+                continue
+            interval = entry.get("interval", 0)
+            if not isinstance(interval, (int, float)):
+                interval = 0
+            if lo <= interval <= hi:
+                remove.add(target)
+    if not remove:
+        return 0
+    _backup_progress()
+    pruned = {k: v for k, v in prog.items() if k not in remove}
+    _save_json(PROGRESS_FILE, pruned)
+    return len(remove)
+
+
 def _push():
     try:
         from utils import get_config, lg
@@ -107,6 +154,7 @@ def _push():
             "admin_hash": _admin_hash(),
             "applied_config_rev": state.get("config_rev", 0),
             "applied_words_rev": state.get("words_rev", 0),
+            "applied_reset_rev": state.get("reset_rev", 0),
             "client_time": datetime.now().isoformat(timespec="seconds"),
         }
 
@@ -147,6 +195,24 @@ def _push():
                 pass
         elif words_part.get("rev"):
             new_state["words_rev"] = words_part["rev"]
+
+        # Progress resets queued by the parent from the web admin. Apply any job
+        # newer than what we've applied, then remember the server's rev so each
+        # reset runs exactly once.
+        reset_part = data.get("reset") or {}
+        reset_jobs = reset_part.get("jobs") or []
+        if isinstance(reset_jobs, list) and reset_jobs:
+            removed = _apply_progress_resets(reset_jobs)
+            new_state["reset_rev"] = reset_part.get("rev", state.get("reset_rev", 0))
+            applied.append(f"reset({removed})")
+            if removed:
+                try:
+                    from sm2 import reload_words
+                    reload_words()
+                except Exception:
+                    pass
+        elif reset_part.get("rev"):
+            new_state["reset_rev"] = reset_part["rev"]
 
         if new_state != state:
             _save_json(SYNC_STATE_FILE, new_state)

--- a/serverside/admin.html
+++ b/serverside/admin.html
@@ -148,6 +148,16 @@
         </div>
         <div id="words-body"><div class="empty">Yükleniyor…</div></div>
       </div>
+
+      <div class="panel" id="reset-panel">
+        <h3>♻️ İlerlemeyi Sıfırla</h3>
+        <div class="desc">Seçilen olgunluk grubundaki kelimeleri "Başlanmadı" durumuna döndürür — SM-2 ilerlemeleri silinir
+          ve günlük yeni kelime sınırına tabi olarak kademeli yeniden tanıtılırlar. Birikmiş tekrar yükünü hafifletmek için
+          kullanışlıdır. İşlem çocuğun cihazına bir sonraki menü açılışında (senkronizasyonda) uygulanır; progress.json orada
+          otomatik yedeklenir.</div>
+        <div class="toolbar" id="reset-buttons"><div class="empty">Yükleniyor…</div></div>
+        <div id="reset-recent" class="desc" style="margin-top:12px"></div>
+      </div>
     </section>
 
     <section class="page" data-page="server">
@@ -280,7 +290,7 @@ function logout(){
 }
 function showApp(){
   $('login').style.display='none'; $('app').style.display='block'; $('logout').style.display='inline-block';
-  loadConfig(); loadWords(); loadEnv();
+  loadConfig(); loadWords(); loadReset(); loadEnv();
 }
 
 // ---- config editor ----
@@ -474,6 +484,39 @@ async function sendReportNow(){
     const msg=e.message==='no_channel'?'Telegram/ntfy ayarlı değil.':('Gönderilemedi: '+e.message);
     box.textContent=msg; toast(msg,true);
   }finally{ btn.disabled=false; btn.textContent=label; }
+}
+
+// ---- progress reset ----
+async function loadReset(){
+  const box=$('reset-buttons');
+  try{
+    const d=await api('/api/admin/reset-progress');
+    box.innerHTML='';
+    (d.buckets||[]).forEach(b=>{
+      const btn=document.createElement('button'); btn.className='danger';
+      btn.textContent='♻️ '+b.label; btn.onclick=()=>queueReset(b.id,b.label);
+      box.appendChild(btn);
+    });
+    if(!(d.buckets||[]).length)box.innerHTML='<div class="empty">Grup yok.</div>';
+    renderResetRecent(d.recent||[]);
+  }catch(e){ box.innerHTML='<div class="empty">Yüklenemedi: '+esc(e.message)+'</div>'; }
+}
+function renderResetRecent(recent){
+  const el=$('reset-recent');
+  if(!recent.length){ el.textContent=''; return; }
+  el.innerHTML='Son sıfırlamalar: '+recent.map(j=>{
+    const when=j.created_at?new Date(j.created_at).toLocaleString('tr-TR'):'';
+    return esc(j.label)+(when?(' ('+esc(when)+')'):'');
+  }).join(' · ');
+}
+async function queueReset(id,label){
+  if(!confirm('"'+label+'" grubundaki kelimeler "Başlanmadı" durumuna döndürülecek.\n\n'+
+    'Bu kelimelerin SM-2 ilerlemesi silinir; çocuğun cihazına bir sonraki senkronizasyonda uygulanır. Devam edilsin mi?'))return;
+  try{
+    await api('/api/admin/reset-progress',{method:'POST',body:{bucket:id}});
+    toast('"'+label+'" sıfırlama kuyruğa alındı. Çocuğun cihazına bir sonraki menü açılışında uygulanacak.');
+    loadReset();
+  }catch(e){ toast('Sıfırlanamadı: '+e.message,true); }
 }
 
 // ---- wire up ----

--- a/serverside/admin_api.py
+++ b/serverside/admin_api.py
@@ -38,8 +38,24 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(BASE_DIR, "data")
 CONFIG_FILE = os.path.join(DATA_DIR, "coalide_config.json")
 WORDS_FILE = os.path.join(DATA_DIR, "coalide_words.json")
+RESET_FILE = os.path.join(DATA_DIR, "coalide_reset.json")
 ADMIN_FILE = os.path.join(DATA_DIR, "admin.json")
 SERVER_ENV = os.path.join(BASE_DIR, ".env")
+
+# SM-2 interval (days) ranges for the stats-screen maturity buckets, mirroring
+# admin.py / stats_menu.py (MATURE_INTERVAL=21). A parent can queue any bucket to
+# be reset to "not started"; the child applies it to progress.json on next sync.
+# The top bucket runs to a large finite bound (JSON has no infinity). Each row is
+# (id, label, lo_interval, hi_interval), lo/hi inclusive.
+RESET_MASTER_HI = 10 ** 9
+RESET_BUCKETS = [
+    ("new",      "Yeni (≤1 gün)",      0, 1),
+    ("learning", "Öğreniliyor (2-6g)", 2, 6),
+    ("young",    "Genç (1-3 hafta)",   7, 20),
+    ("mature",   "Olgun (3h-2 ay)",    21, 59),
+    ("master",   "Usta (2 ay +)",      60, RESET_MASTER_HI),
+]
+RESET_BUCKET_MAP = {b[0]: b for b in RESET_BUCKETS}
 
 SESSION_TTL = 2 * 3600  # seconds
 _sessions = {}          # token -> expiry timestamp
@@ -148,6 +164,17 @@ def sync(payload: dict) -> dict:
             applied = _int(payload.get("applied_words_rev"))
             resp["words"] = {"rev": w["rev"],
                             "data": w["data"] if w["rev"] > applied else None}
+
+        # Progress resets — parent-queued jobs the child applies to its local
+        # progress.json. Return only jobs newer than what the child has applied,
+        # so each reset runs exactly once even if several were queued between syncs.
+        r = _load(RESET_FILE, None)
+        if isinstance(r, dict) and isinstance(r.get("jobs"), list):
+            applied = _int(payload.get("applied_reset_rev"))
+            pending = [j for j in r["jobs"] if _int(j.get("rev")) > applied]
+            resp["reset"] = {"rev": _int(r.get("rev")), "jobs": pending}
+        else:
+            resp["reset"] = {"rev": 0, "jobs": []}
 
         return resp
 
@@ -323,6 +350,42 @@ def delete_word(index: int) -> dict:
         del words[index]
         rev = _bump_words(words)
         return {"rev": rev, "count": len(words), "target": target}
+
+
+# --------------------------------------------------------------------------
+# Progress resets (parent-queued, applied on the child's device)
+# --------------------------------------------------------------------------
+
+def get_reset_state() -> dict:
+    """Current reset revision, the available maturity buckets, and a little
+    recent history — for the web admin's reset panel."""
+    r = _load(RESET_FILE, None)
+    jobs = r.get("jobs", []) if isinstance(r, dict) else []
+    return {
+        "rev": _int(r.get("rev")) if isinstance(r, dict) else 0,
+        "buckets": [{"id": b[0], "label": b[1]} for b in RESET_BUCKETS],
+        "recent": list(reversed(jobs[-10:])),  # newest first
+    }
+
+
+def queue_reset(bucket_id: str) -> dict:
+    """Queue a 'reset this maturity bucket to not started' job for the child to
+    apply on next sync. Returns {rev, label}."""
+    bucket = RESET_BUCKET_MAP.get(str(bucket_id))
+    if not bucket:
+        raise ValueError("Geçersiz olgunluk grubu.")
+    _id, label, lo, hi = bucket
+    with _lock:
+        r = _load(RESET_FILE, None)
+        if not isinstance(r, dict):
+            r = {"rev": 0, "jobs": []}
+        rev = _int(r.get("rev")) + 1
+        jobs = r.get("jobs") if isinstance(r.get("jobs"), list) else []
+        jobs.append({"rev": rev, "bucket": _id, "label": label,
+                     "lo": lo, "hi": hi, "created_at": _now()})
+        # Cap history so the file can't grow without bound.
+        _save(RESET_FILE, {"rev": rev, "jobs": jobs[-200:]})
+        return {"rev": rev, "label": label}
 
 
 # --------------------------------------------------------------------------

--- a/serverside/server.py
+++ b/serverside/server.py
@@ -246,6 +246,11 @@ class Handler(BaseHTTPRequestHandler):
                 return
             return self._send_json(admin_api.get_server_env())
 
+        if path == "/api/admin/reset-progress":
+            if not self._require_admin():
+                return
+            return self._send_json(admin_api.get_reset_state())
+
         if path == "/api/report/preview":
             settings = report.load_settings(HOST, PORT)
             text = report.build_report_text(all_records(), settings["url"])
@@ -285,6 +290,8 @@ class Handler(BaseHTTPRequestHandler):
             return self._post_words()
         if path == "/api/admin/server-env":
             return self._post_server_env()
+        if path == "/api/admin/reset-progress":
+            return self._post_reset_progress()
         if path == "/api/report/send":
             return self._post_send_report()
 
@@ -372,6 +379,18 @@ class Handler(BaseHTTPRequestHandler):
         except Exception as e:
             return self._send_json({"error": str(e)}, status=400)
         return self._send_json({"status": "ok"})
+
+    def _post_reset_progress(self):
+        if not self._require_admin():
+            return
+        payload = self._read_json()
+        if payload is None:
+            return
+        try:
+            result = admin_api.queue_reset(payload.get("bucket", ""))
+        except Exception as e:
+            return self._send_json({"error": str(e)}, status=400)
+        return self._send_json({"status": "ok", **result})
 
     def _post_send_report(self):
         if not self._require_admin():


### PR DESCRIPTION
## What

Lets a parent send any **word-maturity bucket** back to **"Başlanmadı"** (not started), from **both** admin surfaces:

- **In-app admin** (`admin.py`, Words tab): one ♻️ button per bucket — Yeni, Öğreniliyor, Genç, Olgun, Usta — acting directly on the local `progress.json`.
- **Serverside web admin** (`serverside/admin.html`): the same buttons, which **queue** a reset that the child's device applies on its next sync.

## Why

For clearing a review backlog. Resetting a bucket removes those words' SM-2 progress, so they leave the daily due queue and get **re-introduced gradually** under `Daily_New_Word_Cap` (default 15/day) — dropping daily load without losing meaningful progress.

## Buckets

Match the stats screen exactly (`stats_menu.build_stats`, `MATURE_INTERVAL=21`), and partition the started words with no overlap:

| Bucket | SM-2 interval (days) |
|---|---|
| Yeni (≤1 gün) | 0–1 |
| Öğreniliyor (2-6g) | 2–6 |
| Genç (1-3 hafta) | 7–20 |
| Olgun (3h-2 ay) | 21–59 |
| Usta (2 ay +) | 60+ |

## How it works

**In-app admin** — data-driven bucket table, one class-selector dispatch handler, shared confirm→backup→reset path. Removing a word's `progress.json` entry is what returns it to not-started (same mechanism as delete). Backs `progress.json` up to a timestamped `.bak` first; confirms with the affected count.

**Serverside** — the server never touches the child's `progress.json`, so a reset is queued as a revision-tracked job (mirroring how config/words already sync):
- `admin_api`: `coalide_reset.json` store; `queue_reset()` / `get_reset_state()`; `sync()` returns only jobs newer than the child's `applied_reset_rev`, so each reset runs exactly once even if several were queued between syncs.
- `server`: auth-gated `GET`/`POST /api/admin/reset-progress`.
- `config_sync` (child): sends `applied_reset_rev`; applies pending jobs to `progress.json` (interval in `[lo,hi]` → removed), backing it up first, then reloads words.
- `admin.html`: "♻️ İlerlemeyi Sıfırla" panel — a button per bucket, confirm dialog, recent-reset history.

Placed in the **auth-gated admin panel**, not the public dashboard, since it wipes progress and the dashboard has no login.

## Verification

- In-app: all five bucket ranges select the right words and partition the set exactly once; backup written; empty bucket is a no-op; `py_compile` passes.
- Serverside: full HTTP flow tested against an isolated server instance — seed via `/api/sync`, login, `GET` buckets (correct UTF-8 labels), queue, **401 without token**, and child `sync` returns the pending job with the right `[lo,hi]`. Client apply verified against a temp `progress.json` (correct removals, backup, no-op). `/admin` serves the reset panel + JS.

## Notes

- Only `admin.py`, `config_sync.py`, and `serverside/{admin.html,admin_api.py,server.py}` are touched. The pre-existing uncommitted `utils.py` change is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)