### PR TITLE
Make dashboard chart tooltips work on touch (press instead of hover)

### DIFF
--- a/serverside/dashboard.html
+++ b/serverside/dashboard.html
@@ -275,7 +275,11 @@
 
   /* charts */
   .chart-host { width: 100%; min-width: 0; flex: 1 1 auto; min-height: 190px; }
-  svg.chart { display: block; max-width: 100%; overflow: visible; touch-action: pan-y; }
+  svg.chart { display: block; max-width: 100%; overflow: visible; touch-action: pan-y;
+    -webkit-user-select: none; user-select: none; -webkit-touch-callout: none; }
+  /* A press on a chart reveals its tooltip; it must not start a text/element
+     selection or a long-press callout on touch. */
+  .chart-host, .chart-host * { -webkit-user-select: none; user-select: none; -webkit-touch-callout: none; }
   .ax { fill: var(--muted); font-size: 11px; font-variant-numeric: tabular-nums; }
   .dlabel { font-size: 11.5px; font-weight: 700; paint-order: stroke; stroke: var(--surface); stroke-width: 3px; stroke-linejoin: round; }
   .gridline { stroke: var(--grid); stroke-width: 1; }
@@ -393,7 +397,9 @@ function placeTip(x, y) {
   const top = below ? Math.min(y + 14, window.innerHeight - h - pad) : y - 10;
   tip.style.left = left + "px"; tip.style.top = top + "px";
 }
+let _tipHideTimer = null;
 function showTip(title, rows, x, y) {
+  if (_tipHideTimer) { clearTimeout(_tipHideTimer); _tipHideTimer = null; }
   tip.replaceChildren();
   tip.appendChild(txt("div", "tt", title));
   for (const r of rows) {
@@ -409,7 +415,13 @@ function showTip(title, rows, x, y) {
   tip.style.opacity = 1;
   placeTip(x, y);
 }
-function hideTip() { tip.style.opacity = 0; }
+function hideTip() { if (_tipHideTimer) { clearTimeout(_tipHideTimer); _tipHideTimer = null; } tip.style.opacity = 0; }
+// On touch there is no hover, so a tooltip is opened by a press. Keep it up for
+// a moment after the finger lifts so it stays readable instead of vanishing
+// with the release; a mouse still hides immediately on leave.
+function scheduleHideTip(ms = 2200) { if (_tipHideTimer) clearTimeout(_tipHideTimer); _tipHideTimer = setTimeout(() => { tip.style.opacity = 0; _tipHideTimer = null; }, ms); }
+// Chart "pointer leaves the target" handler: mouse hides now, touch lingers.
+function endHover(ev) { (ev && ev.pointerType === "touch") ? scheduleHideTip() : hideTip(); }
 window.addEventListener("scroll", hideTip, { passive: true });
 
 // ---------- cards ----------
@@ -551,7 +563,7 @@ function lineChart(opts) {
   const dots = series.map(se => { const c = s("circle", { r: 4, fill: se.color, stroke: C.surface, "stroke-width": 2, opacity: 0 }); svg.appendChild(c); return c; });
   const hit = s("rect", { class: "hit", x: padL, y: padT, width: plotW, height: plotH });
   svg.appendChild(hit);
-  hit.addEventListener("pointermove", ev => {
+  const scrub = ev => {
     const rect = svg.getBoundingClientRect();
     const vx = (ev.clientX - rect.left) / rect.width * width;
     let i = Math.round((vx - padL) / plotW * (n - 1)); i = Math.max(0, Math.min(n - 1, i));
@@ -560,8 +572,10 @@ function lineChart(opts) {
     const topY = Math.min(...series.map(se => Y(se.values[i])));
     showTip(labels[i], series.map(se => ({ color: se.color, name: se.name, mark: se.mark, value: valueFmt(num(se.values[i])), line: true })),
             rect.left + X(i) / width * rect.width, rect.top + topY / H * rect.height);
-  });
-  hit.addEventListener("pointerleave", () => { cross.setAttribute("opacity", 0); dots.forEach(d => d.setAttribute("opacity", 0)); hideTip(); });
+  };
+  hit.addEventListener("pointermove", scrub);
+  hit.addEventListener("pointerdown", scrub);   // touch: a press reveals the tooltip
+  hit.addEventListener("pointerleave", ev => { cross.setAttribute("opacity", 0); dots.forEach(d => d.setAttribute("opacity", 0)); endHover(ev); });
   return svg;
 }
 
@@ -625,14 +639,17 @@ function columnChart(opts) {
   // hover bands (>=24px where the data allows) drawn last, above the bars
   for (let i = 0; i < n; i++) {
     const hb = s("rect", { class: "hit", x: padL + band * i, y: padT, width: band, height: plotH });
-    hb.addEventListener("pointerenter", () => bars[i].forEach(b => b && b.setAttribute("opacity", .75)));
-    hb.addEventListener("pointermove", ev => {
+    const showBar = ev => {
+      bars[i].forEach(b => b && b.setAttribute("opacity", .75));
       const rect = svg.getBoundingClientRect();
       const topY = Math.min(...series.map(se => Y(se.values[i])));
       showTip(labels[i], series.map(se => ({ color: colorsPerBar ? colorsPerBar[i] : se.color, name: se.name, mark: se.mark, value: valueFmt(num(se.values[i])) })),
               rect.left + (padL + band * i + band / 2) / width * rect.width, rect.top + topY / H * rect.height);
-    });
-    hb.addEventListener("pointerleave", () => { bars[i].forEach(b => b && b.setAttribute("opacity", 1)); hideTip(); });
+    };
+    hb.addEventListener("pointerenter", () => bars[i].forEach(b => b && b.setAttribute("opacity", .75)));
+    hb.addEventListener("pointermove", showBar);
+    hb.addEventListener("pointerdown", showBar);   // touch: a press reveals the tooltip
+    hb.addEventListener("pointerleave", ev => { bars[i].forEach(b => b && b.setAttribute("opacity", 1)); endHover(ev); });
     svg.appendChild(hb);
   }
   return svg;
@@ -643,7 +660,7 @@ function stackedDistribution(rows) {
   const total = rows.reduce((a, r) => a + num(r.value), 0) || 1;
   const wrap = el("div");
   const bar = el("div");
-  bar.style.cssText = "display:flex; height:32px; border-radius:8px; overflow:hidden; background:var(--grid); gap:2px;";
+  bar.style.cssText = "display:flex; height:32px; border-radius:8px; overflow:hidden; background:var(--grid); gap:2px; touch-action:pan-y; user-select:none; -webkit-user-select:none; -webkit-touch-callout:none;";
   rows.forEach(r => {
     if (num(r.value) <= 0) return;
     const seg = el("div");
@@ -651,7 +668,8 @@ function stackedDistribution(rows) {
     const show = ev => showTip(r.label, [{ color: r.color, name: "Kelime", value: fmtNum(r.value) + `  (%${(num(r.value) / total * 100).toFixed(0)})` }], ev.clientX, ev.clientY);
     seg.addEventListener("pointerenter", show);
     seg.addEventListener("pointermove", show);
-    seg.addEventListener("pointerleave", hideTip);
+    seg.addEventListener("pointerdown", show);   // touch: a press reveals the tooltip
+    seg.addEventListener("pointerleave", endHover);
     bar.appendChild(seg);
   });
   wrap.appendChild(bar);
@@ -696,7 +714,8 @@ function donut(opts) {
       const show = ev => { path.setAttribute("stroke-width", thick + 5); showTip(seg.name, [{ color: seg.color, name: "Adet", mark: seg.mark, value: fmtNum(v) + `  (%${(frac * 100).toFixed(0)})` }], ev.clientX, ev.clientY); };
       path.addEventListener("pointerenter", show);
       path.addEventListener("pointermove", show);
-      path.addEventListener("pointerleave", () => { path.setAttribute("stroke-width", thick); hideTip(); });
+      path.addEventListener("pointerdown", show);   // touch: a press reveals the tooltip
+      path.addEventListener("pointerleave", ev => { path.setAttribute("stroke-width", thick); endHover(ev); });
       svg.appendChild(path);
       a0 = a1;
     });


### PR DESCRIPTION
## What

On mobile there's no hover, so the dashboard chart tooltips were unreachable — and pressing a chart tended to **zoom, scroll, or select text** instead of showing the data. This makes a **press** reveal the tooltip, the way hover does on desktop.

## Changes (dashboard.html only)

- **Press to show**: the tooltip "show" is now bound to `pointerdown` (not just `pointermove`) on the line, column, distribution and donut charts, so a tap/press reveals the point's data.
- **No hijacked gestures**: `touch-action: pan-y` (already on the chart SVGs; now also on the distribution bar) lets a **vertical** drag still scroll the page while a **horizontal** drag scrubs across data points, and disables the double-tap zoom on charts.
- **Linger after release**: on a touch pointer the tooltip stays up ~2.2s after the finger lifts (`scheduleHideTip`) instead of vanishing with the release, so a quick tap stays readable. A mouse still hides immediately on leave — `endHover` branches on `event.pointerType`.
- **No accidental selection**: `user-select: none` / `-webkit-touch-callout: none` on charts, so a press no longer starts a text/element selection or a long-press callout.

Desktop hover behaviour is unchanged.

## Verification

- `node --check` on the inline JS.
- In a **mobile-emulated** browser (375×812, touch): dispatching a touch `pointerdown` on a distribution segment, a line/column hit area, etc. opens the tooltip with the correct data; the touch tooltip lingers (verified still visible at 700ms via the timer), while a `pointerType: "mouse"` leave hides it immediately; confirmed `touch-action: pan-y` and `user-select: none` are in effect on the chart SVGs.

## Notes

- Touches only `serverside/dashboard.html`, in different regions from PRs #67/#68, so it merges cleanly alongside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)